### PR TITLE
[chore]: Exception Filter 적용

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,11 @@
+import { ExceptionModule } from './exception/exception.module';
 import { LoggingModule } from './logging/logging.module';
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
-  imports: [LoggingModule],
+  imports: [LoggingModule, ExceptionModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/exception/exception.module.ts
+++ b/src/exception/exception.module.ts
@@ -1,0 +1,8 @@
+import { Logger, Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+@Module({
+  providers: [Logger, { provide: APP_FILTER, useClass: HttpExceptionFilter }],
+})
+export class ExceptionModule {}

--- a/src/exception/http-exception.filter.ts
+++ b/src/exception/http-exception.filter.ts
@@ -1,0 +1,50 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  constructor(private logger: Logger) {}
+
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = (exception as HttpException).getStatus();
+    const error = (exception as HttpException).getResponse() as
+      | string
+      | { error: string; statusCode: number; message: string | string[] };
+    const stack = exception.stack;
+
+    if (!(exception instanceof HttpException)) {
+      exception = new InternalServerErrorException();
+    }
+
+    this.logger.log({
+      timestamp: new Date().toISOString(),
+      url: request.url,
+      error,
+      stack,
+    });
+
+    if (typeof error === 'string') {
+      response.status(status).json({
+        success: false,
+        timestamp: new Date().toISOString(),
+        error,
+      });
+    } else {
+      response.status(status).json({
+        success: false,
+        timestamp: new Date().toISOString(),
+        ...error,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## 작업사항
1. 전역 필터를 사용하려 했으나 , 전역 필터로 적용하면, 필터에 의존성을 주입할 수 없는 제약사항이 생겼음. 왜냐하면 예외 필터의 수행이 예외가 발생한 모듈 외부(main.ts)에서 이루어지기 때문
2. 의존성 주입을 받고자 예외 필터를 커스텀 프로바이더로 등록.
3. HttpExceptionFilter에서 Logger를 주입받아 사용.
4. HttpExceptionFilter에서 예외 처리 도중 콘솔에 로그를 처리하는 부분을 Logger를 이용하도록 변경. 추가로 디버깅을 위해 콜스택을 함께 출력

## 참고
[예외 필터(Exception filter)](https://wikidocs.net/158651)