### PR TITLE
[refac]: Type alias를 활용한 절대경로 설정

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,9 +1,9 @@
-import { CommonResponseFormInterceptor } from '../../../libs/common-config/src/interceptors/common.response.form.interceptor';
 import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { CommonResponseFormInterceptor } from '@app/common-config/interceptors';
+import { RoleEntity, UserEntity } from '@app/entity/domain/user';
+
 import { AppService } from './app.service';
 import { UserShowDto } from './dto/userShow.dto';
-import { UserEntity } from '../../../libs/entity/src/domain/user/user.entity';
-import { RoleEntity } from '../../../libs/entity/src/domain/user/role.entity';
 
 @UseInterceptors(CommonResponseFormInterceptor)
 @Controller()

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,19 +1,23 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { LoggingModule } from '@app/common-config/logging/logging.module';
+import { ExceptionModule } from '@app/common-config/exceptions/exception.module';
+
+import {
+  AuthConfig,
+  DatabaseConfig,
+  ValidationSchema,
+} from '@app/common-config/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { LoggingModule } from '../../../libs/common-config/src/logging/logging.module';
-import { ExceptionModule } from '../../../libs/common-config/src/exceptions/exception.module';
-import { ConfigModule } from '@nestjs/config';
-import { validationSchema } from '../../../libs/common-config/src/config/validationSchema';
-import authConfig from '../../../libs/common-config/src/config/authConfig';
-import databaseConfig from '../../../libs/common-config/src/config/databaseConfig';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
-      load: [databaseConfig, authConfig],
+      load: [DatabaseConfig, AuthConfig],
       isGlobal: true,
-      validationSchema,
+      validationSchema: ValidationSchema,
     }),
     LoggingModule,
     ExceptionModule,

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
-import DatabaseConfig from '../../../libs/common-config/src/config/databaseConfig';
-import AuthConfig from '../../../libs/common-config/src/config/authConfig';
+import { DatabaseConfig, AuthConfig } from '@app/common-config/config';
 
 @Injectable()
 export class AppService {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,7 +7,7 @@ import {
 import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Logger } from '@nestjs/common';
-import { setNestApp } from 'libs/common-config/src/setNextWebApp';
+import { SetNestApp } from '@app/common-config/setNextWebApp';
 
 class Application {
   private logger = new Logger(Application.name);
@@ -21,7 +21,7 @@ class Application {
   }
 
   async bootstrap() {
-    setNestApp(this.server);
+    SetNestApp(this.server);
     await this.server.listen(this.PORT);
   }
 

--- a/apps/api/test/AppController.e2e.spec.ts
+++ b/apps/api/test/AppController.e2e.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
-import { setNestApp } from '../../../libs/common-config/src/setNextWebApp';
+import { AppModule } from '../src/app.module';
+// import { SetNestApp } from '@app/common-config/setNextWebApp';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -13,7 +13,7 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    // setNestApp(app);
+    // SetNestApp(app);
     await app.init();
   });
 

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
-}

--- a/libs/common-config/src/config/authConfig.ts
+++ b/libs/common-config/src/config/authConfig.ts
@@ -1,5 +1,5 @@
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('auth', () => ({
+export const AuthConfig = registerAs('auth', () => ({
   jwtSecret: process.env.JWT_SECRET_KEY,
 }));

--- a/libs/common-config/src/config/databaseConfig.ts
+++ b/libs/common-config/src/config/databaseConfig.ts
@@ -1,6 +1,6 @@
 import { registerAs } from '@nestjs/config';
 
-export default registerAs('database', () => ({
+export const DatabaseConfig = registerAs('database', () => ({
   dbHost: process.env.DB_HOST,
   dbPort: process.env.DB_PORT,
   dbName: process.env.DB_NAME,

--- a/libs/common-config/src/config/index.ts
+++ b/libs/common-config/src/config/index.ts
@@ -1,0 +1,3 @@
+export * from './authConfig';
+export * from './databaseConfig';
+export * from './validationSchema';

--- a/libs/common-config/src/config/validationSchema.ts
+++ b/libs/common-config/src/config/validationSchema.ts
@@ -1,6 +1,6 @@
 import * as Joi from 'joi';
 
-export const validationSchema = Joi.object({
+export const ValidationSchema = Joi.object({
   PORT: Joi.string().required(),
   DB_HOST: Joi.string().required(),
   DB_PORT: Joi.string().required(),

--- a/libs/common-config/src/interceptors/index.ts
+++ b/libs/common-config/src/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from './common.response.form.interceptor';

--- a/libs/common-config/src/setNextWebApp.ts
+++ b/libs/common-config/src/setNextWebApp.ts
@@ -1,6 +1,6 @@
 import { ClassSerializerInterceptor, INestApplication } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 
-export function setNestApp<T extends INestApplication>(app: T): void {
+export function SetNestApp<T extends INestApplication>(app: T): void {
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 }

--- a/libs/entity/src/domain/user/index.ts
+++ b/libs/entity/src/domain/user/index.ts
@@ -1,0 +1,2 @@
+export * from './role.entity';
+export * from './user.entity';

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "supertest": "^6.1.3",
         "ts-jest": "^27.0.3",
         "ts-loader": "^9.2.3",
-        "ts-node": "^10.0.0",
+        "ts-node": "^10.4.0",
+        "tsc-alias": "^1.5.0",
         "tsconfig-paths": "^3.10.1",
         "typescript": "^4.3.5"
       }
@@ -3484,6 +3485,15 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "node_modules/detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4212,6 +4222,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -4536,6 +4558,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/find-node-modules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
+      "integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+      "dev": true,
+      "dependencies": {
+        "findup-sync": "^4.0.0",
+        "merge": "^2.1.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4547,6 +4579,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+      "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/flat-cache": {
@@ -4860,6 +4907,48 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
+    "node_modules/global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/globals": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
@@ -4940,6 +5029,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -5113,6 +5214,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/inquirer": {
       "version": "7.3.3",
@@ -5314,6 +5421,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/isarray": {
@@ -6660,6 +6776,12 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "node_modules/merge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+      "dev": true
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -6795,6 +6917,19 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/mylas": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.7.tgz",
+      "integrity": "sha512-bSsErQQnYdNE/qa0u2WBjZbTgngELOPgfEs+pgHEsHPNHo/CfVg2cZyc3VcCWtgEcdgxpa+IYec1ah04FlW3Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7130,6 +7265,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parse5": {
@@ -7537,6 +7681,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -8649,6 +8806,32 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.5.0.tgz",
+      "integrity": "sha512-Pb3y7ZjULKFHEV2US5dS58/hV76sE9Sn5iehiPjYqHcm/lx4eCGAJYoSmrVXQMPX+6baTnDFJD0MGOyqn94dIg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "commander": "^8.3.0",
+        "find-node-modules": "^2.1.2",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.6",
+        "normalize-path": "^3.0.0"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -12111,6 +12294,12 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -12663,6 +12852,15 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "expect": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.6.tgz",
@@ -12947,6 +13145,16 @@
         }
       }
     },
+    "find-node-modules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.2.tgz",
+      "integrity": "sha512-x+3P4mbtRPlSiVE1Qco0Z4YLU8WFiFcuWTf3m75OV9Uzcfs2Bg+O9N+r/K0AnmINBW06KpfqKwYJbFlFq4qNug==",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^4.0.0",
+        "merge": "^2.1.0"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -12955,6 +13163,18 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+      "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "resolve-dir": "^1.0.1"
       }
     },
     "flat-cache": {
@@ -13173,6 +13393,41 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "globals": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
@@ -13227,6 +13482,15 @@
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -13348,6 +13612,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.3.3",
@@ -13497,6 +13767,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
@@ -14554,6 +14830,12 @@
         }
       }
     },
+    "merge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -14655,6 +14937,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "mylas": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.7.tgz",
+      "integrity": "sha512-bSsErQQnYdNE/qa0u2WBjZbTgngELOPgfEs+pgHEsHPNHo/CfVg2cZyc3VcCWtgEcdgxpa+IYec1ah04FlW3Gw==",
       "dev": true
     },
     "natural-compare": {
@@ -14917,6 +15205,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "6.0.1",
@@ -15208,6 +15502,16 @@
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         }
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -16007,6 +16311,28 @@
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
+    "tsc-alias": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.5.0.tgz",
+      "integrity": "sha512-Pb3y7ZjULKFHEV2US5dS58/hV76sE9Sn5iehiPjYqHcm/lx4eCGAJYoSmrVXQMPX+6baTnDFJD0MGOyqn94dIg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "commander": "^8.3.0",
+        "find-node-modules": "^2.1.2",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.6",
+        "normalize-path": "^3.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   "license": "UNLICENSED",
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "build": "nest build && tsc-alias",
+    "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",
     "start:dev": "NODE_ENV=development nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
+    "test:dev": "jest --env=dev",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -52,7 +53,8 @@
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.0.0",
+    "ts-node": "^10.4.0",
+    "tsc-alias": "^1.5.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
   },
@@ -62,7 +64,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -71,6 +73,15 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/apps/",
+      "<rootDir>/libs/"
+    ],
+    "moduleNameMapper": {
+      "^@app/entity(|/.*)$": "<rootDir>/libs/entity/src/$1",
+      "^@app/utils(|/.*)$": "<rootDir>/libs/utils/src/$1",
+      "^@app/common-config(|/.*)$": "<rootDir>/libs/common-config/src/$1"
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,26 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "@app/entity": [
+        "libs/entity/src"
+      ],
+      "@app/entity/*": [
+        "libs/entity/src/*"
+      ],
+      "@app/utils": [
+        "libs/utils/src"
+      ],
+      "@app/utils/*": [
+        "libs/utils/src/*"
+      ],
+      "@app/common-config": [
+        "libs/common-config/src"
+      ],
+      "@app/common-config/*": [
+        "libs/common-config/src/*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## 작업사항
1. 배럴(barrel)을 활용한 경로 설정
2. Alias imports를 활용한 상대경로 방식 제거

## 참고
[alias를 사용하여 import 구문을 깨끗하게 만들자!](https://aerocode.net/335?category=740143)
[barrel를 사용하여 import 구문을 깨끗하게 만들자!](https://aerocode.net/334?category=740143)
[NestJS에서 path alias 설정하기 (feat. TypeORM, Jest)](https://velog.io/@modolee/nestjs-path-alias-feat-typeorm-jest)