### PR TITLE
[test]: 테스트 DB 환경 구축

### DIFF
--- a/apps/api/test/integration/domain/auth/AuthApiService.int.spec.ts
+++ b/apps/api/test/integration/domain/auth/AuthApiService.int.spec.ts
@@ -6,6 +6,12 @@ import { UserModule } from '@app/entity/domain/user/UserModule';
 
 import { User } from '@app/entity/domain/user/User.entity';
 import { getPgTestTypeOrmModule } from '../../../../../../libs/entity/test/getPgTestTypeOrmModule';
+import { ConfigModule } from '@nestjs/config';
+import {
+  AuthConfig,
+  TestDatabaseConfig,
+  ValidationSchema,
+} from '@app/common-config/config';
 
 describe('AuthApiService', () => {
   let userRepository: Repository<User>;
@@ -13,7 +19,15 @@ describe('AuthApiService', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [UserModule, getPgTestTypeOrmModule()],
+      imports: [
+        UserModule,
+        ConfigModule.forRoot({
+          load: [TestDatabaseConfig, AuthConfig],
+          isGlobal: true,
+          validationSchema: ValidationSchema,
+        }),
+        getPgTestTypeOrmModule(),
+      ],
       providers: [AuthApiService, UserApiService],
     }).compile();
 

--- a/libs/common-config/src/config/index.ts
+++ b/libs/common-config/src/config/index.ts
@@ -1,3 +1,4 @@
 export * from './authConfig';
 export * from './databaseConfig';
 export * from './validationSchema';
+export * from './testDatabaseConfig';

--- a/libs/common-config/src/config/testDatabaseConfig.ts
+++ b/libs/common-config/src/config/testDatabaseConfig.ts
@@ -1,0 +1,9 @@
+import { registerAs } from '@nestjs/config';
+
+export const TestDatabaseConfig = registerAs('testDatabase', () => ({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  database: process.env.DB_DEV_NAME,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+}));

--- a/libs/common-config/src/config/validationSchema.ts
+++ b/libs/common-config/src/config/validationSchema.ts
@@ -7,5 +7,12 @@ export const ValidationSchema = Joi.object({
   DB_NAME: Joi.string().required(),
   DB_USERNAME: Joi.string().required(),
   DB_PASSWORD: Joi.string().required(),
+  LOGGING: Joi.string().required(),
+  SYNCHRONIZE: Joi.string().required(),
+
+  DB_DEV_NAME: Joi.string().required(),
+  DEV_LOGGING: Joi.string().required(),
+  DEV_SYNCHRONIZE: Joi.string().required(),
+
   JWT_SECRET_KEY: Joi.string().required(),
 });

--- a/libs/entity/getTypeOrmModule.ts
+++ b/libs/entity/getTypeOrmModule.ts
@@ -5,6 +5,9 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 
 export const getRealTypeOrmModule = () => {
   const entityPath = path.join(__dirname, 'src/domain/**/*.entity.{js, ts}');
+  const logging = process.env.LOGGING;
+  const synchronize = process.env.SYNCHRONIZE;
+
   return TypeOrmModule.forRootAsync({
     imports: [ConfigModule],
     useFactory: (configService: ConfigService): TypeOrmModuleOptions =>
@@ -12,9 +15,8 @@ export const getRealTypeOrmModule = () => {
         type: 'postgres',
         entities: [entityPath],
         autoLoadEntities: true,
-        synchronize:
-          configService.get('NODE_ENV') === 'development' ? true : false,
-        logging: configService.get('NODE_ENV') === 'development' ? true : false,
+        synchronize: synchronize === 'false' ? false : Boolean(synchronize),
+        logging: logging === 'false' ? false : Boolean(logging),
         namingStrategy: new SnakeNamingStrategy(),
       }),
 

--- a/libs/entity/test/unit/domain/user/UserRepository.pg.spec.ts
+++ b/libs/entity/test/unit/domain/user/UserRepository.pg.spec.ts
@@ -3,13 +3,27 @@ import { User } from '@app/entity/domain/user/User.entity';
 import { getConnection, Repository } from 'typeorm';
 import { UserModule } from '@app/entity/domain/user/UserModule';
 import { getPgTestTypeOrmModule } from '../../../getPgTestTypeOrmModule';
+import { ConfigModule } from '@nestjs/config';
+import {
+  AuthConfig,
+  TestDatabaseConfig,
+  ValidationSchema,
+} from '@app/common-config/config';
 
 describe('UserRepository', () => {
   let userRepository: Repository<User>;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [UserModule, getPgTestTypeOrmModule()],
+      imports: [
+        UserModule,
+        ConfigModule.forRoot({
+          load: [TestDatabaseConfig, AuthConfig],
+          isGlobal: true,
+          validationSchema: ValidationSchema,
+        }),
+        getPgTestTypeOrmModule(),
+      ],
     }).compile();
 
     userRepository = module.get('UserRepository');


### PR DESCRIPTION
## 작업사항
1. TestDB와 실서버 DB의 환경 설정을 다르게 했던 것을 동일하게 설정
2. 팩토리 프로바이더의 ConfigService DI를 위해 테스트 환경에서 ConfigModule을 imports로 추가
3. 로깅, 동기화 설정 변경

## 관계된 이슈, PR 
#2 