### PR TITLE
[chore]: 헬스 체크 로직 구성

### DIFF
--- a/apps/api/src/ApiAppModule.ts
+++ b/apps/api/src/ApiAppModule.ts
@@ -1,8 +1,11 @@
+import { HealthCheckController } from './health-check/HealthCheckController';
 import { getRealTypeOrmModule } from '../../../libs/entity/getTypeOrmModule';
 // import { getPgTestTypeOrmModule } from '../../../libs/entity/test/getPgTestTypeOrmModule';
 import { LoggingModule } from '@app/common-config/logging/logging.module';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { TerminusModule } from '@nestjs/terminus';
+import { HttpModule } from '@nestjs/axios';
 
 import {
   AuthConfig,
@@ -24,6 +27,9 @@ import { UserApiModule } from './user/UserApiModule';
     LoggingModule,
     AuthApiModule,
     UserApiModule,
+    TerminusModule,
+    HttpModule,
   ],
+  controllers: [HealthCheckController],
 })
 export class ApiAppModule {}

--- a/apps/api/src/health-check/HealthCheckController.ts
+++ b/apps/api/src/health-check/HealthCheckController.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheckService,
+  HttpHealthIndicator,
+  TypeOrmHealthIndicator,
+  HealthCheck,
+} from '@nestjs/terminus';
+
+@Controller('health-check')
+export class HealthCheckController {
+  constructor(
+    private health: HealthCheckService,
+    // private http: HttpHealthIndicator,
+    private db: TypeOrmHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  check() {
+    return this.health.check([
+      // () => this.http.pingCheck('nestjs-docs', 'https://docs.nestjs.com'),
+      () => this.db.pingCheck('database'),
+    ]);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^0.0.5",
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^1.1.6",
         "@nestjs/core": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
         "@nestjs/swagger": "^5.2.0",
+        "@nestjs/terminus": "^8.0.4",
         "@nestjs/typeorm": "^8.0.3",
         "bcrypt": "^5.0.1",
         "class-transformer": "^0.5.1",
@@ -1324,6 +1326,27 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.5.tgz",
+      "integrity": "sha512-kpgCX6JAXcntj+4fk5Sk7Nu6HXvyOKyhRgnuaIQpwbcdthrPfOBVmJo+ZJf2bbSze+YaoodeH9Fe1WkSiN1xrg==",
+      "dependencies": {
+        "axios": "0.25.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@nestjs/axios/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-8.2.0.tgz",
@@ -1605,6 +1628,20 @@
         "swagger-ui-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/terminus": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-8.0.4.tgz",
+      "integrity": "sha512-KjeY7VLt0Az6pA2wO67nkL1QbE68yBb+FLZ7+aa+C/g/IKoDR668nqSuFzJarBrnFBTGEwDD09BwsgqkmymrbQ==",
+      "dependencies": {
+        "check-disk-space": "3.1.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "8.x",
+        "@nestjs/core": "8.x",
+        "reflect-metadata": "0.1.x",
+        "rxjs": "7.x"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -3184,6 +3221,14 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-disk-space": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.1.0.tgz",
+      "integrity": "sha512-4L3WVw4uPaBJocwnxTCWTTHc8mNu080pjCVBhZeWFdnaQBAremLHpJ1H90G+uEA0rJcW43fghYMsLBXID9X4Zg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -11448,6 +11493,24 @@
         "tar": "^6.1.11"
       }
     },
+    "@nestjs/axios": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.5.tgz",
+      "integrity": "sha512-kpgCX6JAXcntj+4fk5Sk7Nu6HXvyOKyhRgnuaIQpwbcdthrPfOBVmJo+ZJf2bbSze+YaoodeH9Fe1WkSiN1xrg==",
+      "requires": {
+        "axios": "0.25.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        }
+      }
+    },
     "@nestjs/cli": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-8.2.0.tgz",
@@ -11609,6 +11672,14 @@
         "@nestjs/mapped-types": "1.0.1",
         "lodash": "4.17.21",
         "path-to-regexp": "3.2.0"
+      }
+    },
+    "@nestjs/terminus": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-8.0.4.tgz",
+      "integrity": "sha512-KjeY7VLt0Az6pA2wO67nkL1QbE68yBb+FLZ7+aa+C/g/IKoDR668nqSuFzJarBrnFBTGEwDD09BwsgqkmymrbQ==",
+      "requires": {
+        "check-disk-space": "3.1.0"
       }
     },
     "@nestjs/testing": {
@@ -12841,6 +12912,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "check-disk-space": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.1.0.tgz",
+      "integrity": "sha512-4L3WVw4uPaBJocwnxTCWTTHc8mNu080pjCVBhZeWFdnaQBAremLHpJ1H90G+uEA0rJcW43fghYMsLBXID9X4Zg=="
     },
     "chokidar": {
       "version": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "test:e2e": "NODE_ENV=development jest --config ./apps/api/test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^0.0.5",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^1.1.6",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/swagger": "^5.2.0",
+    "@nestjs/terminus": "^8.0.4",
     "@nestjs/typeorm": "^8.0.3",
     "bcrypt": "^5.0.1",
     "class-transformer": "^0.5.1",


### PR DESCRIPTION
## 작업사항
1. DB에 부하가 생길 시, 장애 대응을 위해 현재 서비스가 건강한 상태인지 체크하는 장치가 필요했음
2. 건강 체크를 위한 로직을 추가하기 위해 Terminus 적용

### Terminus 라이브러리 설치
`npm i @nestjs/terminus`

상태확인은 특정 라우터 엔드포인트(ex. @GET /health-check)로 요청을 보내고 응답을 확인하는 방법을 사용합니다. 이를 위한 HealthCheckController 컨트롤러를 생성했고, ApiAppModule에 TerminusModule을 imports했습니다. 

### 헬스 체크
`npm i @nestjs/axios`

HTTP 헬스 체크 로직을 추가하기 위해 @nestjs/axios 라이브러리를 설치했습니다. 그 후 이를 활용하기 위해 ApiAppModule에 HttpModule을 imports 했습니다.

그 후 HealthCheckController에서 health, http, db 맴버 변수에 의존성을 주입했고, 현재는 TypeOrmHealthCheck만 가능하도록 로직을 구성했습니다.


### TypeORM 헬스 체크 결과
`$ curl http://localhost:3000/health-check
{
    "status": "ok",
    "info": {
        "nestjs-docs": {
            "status": "up"
        },
        "database": {
            "status": "up"
        }
    },
    "error": {},
    "details": {
        "nestjs-docs": {
            "status": "up"
        },
        "database": {
            "status": "up"
        }
    }
}`

TypeOrmHealthIndicator는 단순히 DB가 잘 살아있는지 확인합니다. 이를 위해 SELECT 1 구문을 실행해 봅니다. 


## 관계된 이슈, PR 
#29 