### PR TITLE
[refac]: 회원가입 로직에서 service에서 service로 이동하는 로직 변경

### DIFF
--- a/apps/api/src/auth/AuthApiModule.ts
+++ b/apps/api/src/auth/AuthApiModule.ts
@@ -9,7 +9,6 @@ import { getWinstonLogger } from '@app/common-config/getWinstonLogger';
 @Module({
   imports: [
     UserModule,
-    UserApiModule,
     WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'api')),
   ],
   controllers: [AuthApiController],

--- a/apps/api/src/auth/AuthApiService.ts
+++ b/apps/api/src/auth/AuthApiService.ts
@@ -1,12 +1,20 @@
-import { UserApiService } from './../user/UserApiService';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { User } from '@app/entity/domain/user/User.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class AuthApiService {
-  constructor(private readonly userApiService: UserApiService) {}
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
 
   async signup(signupUser: User): Promise<void> {
-    await this.userApiService.create(signupUser);
+    await this.create(signupUser);
+  }
+
+  async create(user: User): Promise<void> {
+    await this.userRepository.save(user);
   }
 }

--- a/apps/api/src/user/UserApiModule.ts
+++ b/apps/api/src/user/UserApiModule.ts
@@ -7,6 +7,5 @@ import { UserModule } from '@app/entity/domain/user/UserModule';
   imports: [UserModule],
   controllers: [UserApiController],
   providers: [UserApiService],
-  exports: [UserApiService],
 })
 export class UserApiModule {}

--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -1,16 +1,4 @@
-import { User } from '@app/entity/domain/user/User.entity';
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 
 @Injectable()
-export class UserApiService {
-  constructor(
-    @InjectRepository(User)
-    private userRepository: Repository<User>,
-  ) {}
-
-  async create(user: User): Promise<void> {
-    await this.userRepository.save(user);
-  }
-}
+export class UserApiService {}

--- a/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
+++ b/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
@@ -5,7 +5,6 @@ import { AuthApiService } from '../../../../src/auth/AuthApiService';
 
 describe('AuthApiService', () => {
   let authApiService: AuthApiService;
-  let userApiService: UserApiService;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -13,14 +12,9 @@ describe('AuthApiService', () => {
     }).compile();
 
     authApiService = module.get<AuthApiService>(AuthApiService);
-    userApiService = module.get<UserApiService>(UserApiService);
   });
 
   it('should be defined', () => {
     expect(authApiService).toBeDefined();
-  });
-
-  it('should be defined', () => {
-    expect(userApiService).toBeDefined();
   });
 });

--- a/apps/api/test/unit/domain/user/UserApiService.spec.ts
+++ b/apps/api/test/unit/domain/user/UserApiService.spec.ts
@@ -1,13 +1,9 @@
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { ApiAppModule } from './../../../../src/ApiAppModule';
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserApiService } from '../../../../src/user/UserApiService';
-import { User } from '@app/entity/domain/user/User.entity';
 
 describe('UserApiService', () => {
   let service: UserApiService;
-  let userRepository: Repository<User>;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -15,14 +11,9 @@ describe('UserApiService', () => {
     }).compile();
 
     service = module.get<UserApiService>(UserApiService);
-    userRepository = module.get(getRepositoryToken(User));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
-  });
-
-  it('should be defined', () => {
-    expect(userRepository).toBeDefined();
   });
 });


### PR DESCRIPTION
## 작업사항
1. 기존에는 회원가입 로직에서 AuthApiService에서 UserApiService을 불러와서 회원가입을 처리했었음.
2. 이 로직을 활용해도 좋지만, Service에서 바로 Repository로 넘어가는 로직이 훗날 테스트 코드를 작성할 때 유리하다고 생각했음.
3. 그러므로 회원가입 로직은 User로 넘어가지 않고 Auth 도메인에서만 처리되도록 수정

## 관계된 이슈, PR 
#1 