### PR TITLE
[feat]: 푸시알림 허용 여부 변경 API 로직 생성

### DIFF
--- a/apps/api/src/user/UserApiController.ts
+++ b/apps/api/src/user/UserApiController.ts
@@ -15,6 +15,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { NotFoundError } from '@app/common-config/response/swagger/common/error/NotFoundError';
+import { UserUpdatePushReq } from './dto/UserUpdatePushReq.dto';
+import { pushUpdateFail } from '@app/common-config/response/swagger/domain/user/pushUpdateFail';
 
 @Controller('user')
 @ApiTags('유저 API')
@@ -41,7 +43,7 @@ export class UserApiController {
     type: NotFoundError,
   })
   @ApiInternalServerErrorResponse({
-    description: '로그인에 실패했습니다.',
+    description: 'FCM 토큰 수정에 실패했습니다.',
     type: fcmTokenUpdateFail,
   })
   @Put('/fcmToken')
@@ -58,6 +60,45 @@ export class UserApiController {
           '입력된 deviceId가 존재하지 않습니다.',
         );
       return ResponseEntity.ERROR_WITH('FCM 토큰 수정에 실패했습니다.');
+    }
+  }
+
+  @ApiOperation({
+    summary: '푸시알림 허용 여부 수정',
+    description: `
+    푸시알림 허용 여부 수정 시 deviceId, isPush를 입력받습니다. \n
+    푸시알림 허용 여부 수정 시 입력값을 누락한 경우 400 에러를 출력합니다. \n
+    푸시알림 허용 여부 수정 시 deviceId가 DB에 저장되어 있지 않다면 404 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '푸시알림 허용 여부 수정에 성공했습니다.',
+    type: OkSuccess,
+  })
+  @ApiNotFoundResponse({
+    description: '입력한 deviceId는 DB에 저장되어 있지 않습니다.',
+    type: NotFoundError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '푸시알림 허용 여부 수정에 실패했습니다.',
+    type: pushUpdateFail,
+  })
+  @Put('/push')
+  async updatePush(
+    @Body() dto: UserUpdatePushReq,
+  ): Promise<ResponseEntity<string>> {
+    try {
+      await this.userApiService.updatePush(await dto.toEntity());
+      return ResponseEntity.OK();
+    } catch (error) {
+      this.logger.error(`dto = ${JSON.stringify(dto)}`, error);
+      if (error.status === ResponseStatus.NOT_FOUND)
+        return ResponseEntity.NOT_FOUND_WITH(
+          '입력된 deviceId가 존재하지 않습니다.',
+        );
+      return ResponseEntity.ERROR_WITH(
+        '푸시알림 허용 여부 수정에 실패했습니다.',
+      );
     }
   }
 }

--- a/apps/api/src/user/UserApiRepository.ts
+++ b/apps/api/src/user/UserApiRepository.ts
@@ -18,4 +18,12 @@ export class UserApiRepository extends Repository<User> {
       .where(`deviceId =:deviceId`, { deviceId });
     return await queryBuilder.execute();
   }
+
+  async updatePush(deviceId: string, isPush: boolean) {
+    const queryBuilder = createQueryBuilder()
+      .update(User)
+      .set({ isPush })
+      .where(`deviceId =:deviceId`, { deviceId });
+    return await queryBuilder.execute();
+  }
 }

--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -5,14 +5,23 @@ import { User } from '@app/entity/domain/user/User.entity';
 
 @Injectable()
 export class UserApiService {
-  constructor(private readonly UserApiRepository: UserApiRepository) {}
+  constructor(private readonly userApiRepository: UserApiRepository) {}
 
   async updateFcmToken(fcmTokenUser: User): Promise<UpdateResult> {
-    const isUpdateFcmToken = await this.UserApiRepository.updateFirebaseToken(
+    const isUpdateFcmToken = await this.userApiRepository.updateFirebaseToken(
       fcmTokenUser.firebaseToken,
       fcmTokenUser.deviceId,
     );
     if (isUpdateFcmToken.affected === 0) throw new NotFoundException();
     return isUpdateFcmToken;
+  }
+
+  async updatePush(pushUser: User): Promise<UpdateResult> {
+    const isUpdatePush = await this.userApiRepository.updatePush(
+      pushUser.deviceId,
+      pushUser.isPush,
+    );
+    if (isUpdatePush.affected === 0) throw new NotFoundException();
+    return isUpdatePush;
   }
 }

--- a/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
+++ b/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@app/entity/domain/user/User.entity';
+import { Expose } from 'class-transformer';
+import { IsNotEmpty, IsBoolean, IsString } from 'class-validator';
+
+export class UserUpdatePushReq {
+  @ApiProperty({
+    example: 'test',
+    description: '푸시알림 허용 여부 변경을 위해 입력 받는 deviceId입니다.',
+    required: true,
+  })
+  @Expose()
+  @IsNotEmpty()
+  @IsString()
+  deviceId: string;
+
+  @ApiProperty({
+    example: true,
+    description: '푸시알림 허용 여부 변경을 위해 입력 받는 isPush입니다.',
+    required: true,
+  })
+  @Expose()
+  @IsNotEmpty()
+  @IsBoolean()
+  isPush: boolean;
+
+  toEntity(): Promise<User> {
+    return User.updatePush(this.deviceId, this.isPush);
+  }
+}

--- a/libs/common-config/src/response/swagger/domain/user/pushUpdateFail.ts
+++ b/libs/common-config/src/response/swagger/domain/user/pushUpdateFail.ts
@@ -1,0 +1,16 @@
+import { InternalServerError } from '../../common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class pushUpdateFail extends PickType(InternalServerError, [
+  'statusCode',
+  'data',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: '푸시알림 허용 여부 수정에 실패했습니다.',
+    description: '푸시알림 허용 여부 수정에 실패했습니다.',
+  })
+  message: string;
+}

--- a/libs/entity/src/domain/user/User.entity.ts
+++ b/libs/entity/src/domain/user/User.entity.ts
@@ -90,4 +90,11 @@ export class User extends BaseTimeEntity {
     user.firebaseToken = firebaseToken;
     return user;
   }
+
+  static async updatePush(deviceId: string, isPush: boolean): Promise<User> {
+    const user = new User();
+    user.deviceId = deviceId;
+    user.isPush = isPush;
+    return user;
+  }
 }


### PR DESCRIPTION

## 작업사항
1. 클라이언트에게 isPush, deviceId를 입력받으면, deviceId에 해당하는 isPush를 DB에서 찾아서 그 값을 새로운 isPush 값으로 변경
2. 만약 DB에 값이 없으면 404 에러 전달

To Do List
- [ ] 테스트 코드 작성


## 관계된 이슈, PR 
#56 