### PR TITLE
[fix]: findUserIdByDeviceId Entity -> DTO 변환 로직 수정

### DIFF
--- a/libs/entity/src/domain/user/UserId.ts
+++ b/libs/entity/src/domain/user/UserId.ts
@@ -1,9 +1,6 @@
 import { Expose } from 'class-transformer';
 
 export class UserId {
-  @Expose({ name: 'userId' })
-  id: string;
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {}
+  @Expose({ name: 'user_id' })
+  userId: string;
 }


### PR DESCRIPTION

## 작업사항
1. 기존 로직은 Entity에서 DTO로 변환이 제대로 이뤄지지 않았음.
2. Expose안에서 DB 컬럼 이름을 정확하게 입력하지 않아서 변환이 제대로 이뤄지지 않았고 이를 변경함

## 관계된 이슈, PR 