### PR TITLE
[feat]: JwtAuthGuard를 활용한 토큰 활용 로직 추가

### DIFF
--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -1,16 +1,25 @@
+import { UserUpdateFcmTokenReq } from './dto/UserUpdateFcmTokenReq.dto';
 import { UserApiRepository } from './UserApiRepository';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { UpdateResult } from 'typeorm';
 import { User } from '@app/entity/domain/user/User.entity';
+import { JwtPayload } from '@app/common-config/jwt/JwtPayload';
 
 @Injectable()
 export class UserApiService {
   constructor(private readonly userApiRepository: UserApiRepository) {}
 
-  async updateFcmToken(fcmTokenUser: User): Promise<UpdateResult> {
+  async updateFcmToken(
+    userUpdateFcmTokenDto: UserUpdateFcmTokenReq,
+    userDto: JwtPayload,
+  ): Promise<UpdateResult> {
+    const user: User = await User.updateFcmToken(
+      userUpdateFcmTokenDto.firebaseToken,
+      userDto.deviceId,
+    );
     const isUpdateFcmToken = await this.userApiRepository.updateFirebaseToken(
-      fcmTokenUser.firebaseToken,
-      fcmTokenUser.deviceId,
+      user.firebaseToken,
+      user.deviceId,
     );
     if (isUpdateFcmToken.affected === 0) throw new NotFoundException();
     return isUpdateFcmToken;

--- a/apps/api/src/user/dto/UserUpdateFcmTokenReq.dto.ts
+++ b/apps/api/src/user/dto/UserUpdateFcmTokenReq.dto.ts
@@ -6,16 +6,6 @@ import { IsNotEmpty, IsString } from 'class-validator';
 export class UserUpdateFcmTokenReq {
   @ApiProperty({
     example: 'test',
-    description: 'FCM 토큰 수정시 입력 받는 deviceId입니다.',
-    required: true,
-  })
-  @Expose()
-  @IsNotEmpty()
-  @IsString()
-  deviceId: string;
-
-  @ApiProperty({
-    example: 'test',
     description: 'FCM 토큰 수정시 입력 받는 firebaseToken입니다.',
     required: true,
   })
@@ -23,8 +13,4 @@ export class UserUpdateFcmTokenReq {
   @IsNotEmpty()
   @IsString()
   firebaseToken: string;
-
-  toEntity(): Promise<User> {
-    return User.updateFcmToken(this.deviceId, this.firebaseToken);
-  }
 }

--- a/libs/common-config/src/decorator/UserDecorator.ts
+++ b/libs/common-config/src/decorator/UserDecorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    if (request.user) return request.user;
+    else null;
+  },
+);

--- a/libs/common-config/src/jwt/JwtPayload.ts
+++ b/libs/common-config/src/jwt/JwtPayload.ts
@@ -1,5 +1,5 @@
 export class JwtPayload {
-  userId: string;
+  userId: number;
   deviceId: string;
   iat?: number;
   exp?: number;

--- a/libs/common-config/src/response/ResponseStatus.ts
+++ b/libs/common-config/src/response/ResponseStatus.ts
@@ -5,6 +5,7 @@ export const ResponseStatus = {
   BAD_PARAMETER: 400,
   FORBIDDEN: 403,
   NOT_FOUND: 404,
+  UN_AUTHORIZED: 401,
 } as const;
 
 export type ResponseStatus = typeof ResponseStatus[keyof typeof ResponseStatus];

--- a/libs/entity/src/domain/user/User.entity.ts
+++ b/libs/entity/src/domain/user/User.entity.ts
@@ -81,9 +81,16 @@ export class User extends BaseTimeEntity {
     return user;
   }
 
+  static async jwtUserReq(deviceId: string, userId: number): Promise<User> {
+    const user = new User();
+    user.deviceId = deviceId;
+    user.id = userId;
+    return user;
+  }
+
   static async updateFcmToken(
-    deviceId: string,
     firebaseToken: string,
+    deviceId: string,
   ): Promise<User> {
     const user = new User();
     user.deviceId = deviceId;

--- a/libs/entity/src/domain/user/UserId.ts
+++ b/libs/entity/src/domain/user/UserId.ts
@@ -2,5 +2,5 @@ import { Expose } from 'class-transformer';
 
 export class UserId {
   @Expose({ name: 'user_id' })
-  userId: string;
+  userId: number;
 }


### PR DESCRIPTION
## 작업사항
1. JwtAuthGuard를 활용해서 헤더값으로 들어오는 토큰을 활용할 수 있음
2. 커스텀 데코레이터 CurrentUser를 활용해서, 토큰의 페이로드 값 활용
3. DTO를 컨트롤러에서 Entity로 만드는 것에서, 서비스에서 Entity로 변경하는 로직으로 변경

## 관계된 이슈, PR 
#3 #4 