### PR TITLE
[fix]: 푸시알림 허용 여부 변경 API 로직 수정

### DIFF
--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -4,6 +4,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { UpdateResult } from 'typeorm';
 import { User } from '@app/entity/domain/user/User.entity';
 import { JwtPayload } from '@app/common-config/jwt/JwtPayload';
+import { UserUpdatePushReq } from './dto/UserUpdatePushReq.dto';
 
 @Injectable()
 export class UserApiService {
@@ -25,12 +26,18 @@ export class UserApiService {
     return isUpdateFcmToken;
   }
 
-  async updatePush(pushUser: User): Promise<UpdateResult> {
-    const isUpdatePush = await this.userApiRepository.updatePush(
-      pushUser.deviceId,
-      pushUser.isPush,
+  async updatePush(
+    UserUpdatePushDto: UserUpdatePushReq,
+    userDto: JwtPayload,
+  ): Promise<UpdateResult> {
+    const user: User = await User.updatePush(
+      userDto.deviceId,
+      UserUpdatePushDto.isPush,
     );
-    if (isUpdatePush.affected === 0) throw new NotFoundException();
+    const isUpdatePush = await this.userApiRepository.updatePush(
+      user.deviceId,
+      user.isPush,
+    );
     return isUpdatePush;
   }
 }

--- a/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
+++ b/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
@@ -1,19 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from '@app/entity/domain/user/User.entity';
 import { Expose } from 'class-transformer';
-import { IsNotEmpty, IsBoolean, IsString } from 'class-validator';
+import { IsNotEmpty, IsBoolean } from 'class-validator';
 
 export class UserUpdatePushReq {
-  @ApiProperty({
-    example: 'test',
-    description: '푸시알림 허용 여부 변경을 위해 입력 받는 deviceId입니다.',
-    required: true,
-  })
-  @Expose()
-  @IsNotEmpty()
-  @IsString()
-  deviceId: string;
-
   @ApiProperty({
     example: true,
     description: '푸시알림 허용 여부 변경을 위해 입력 받는 isPush입니다.',
@@ -23,8 +12,4 @@ export class UserUpdatePushReq {
   @IsNotEmpty()
   @IsBoolean()
   isPush: boolean;
-
-  toEntity(): Promise<User> {
-    return User.updatePush(this.deviceId, this.isPush);
-  }
 }

--- a/libs/common-config/src/response/swagger/common/error/UnauthorizedError.ts
+++ b/libs/common-config/src/response/swagger/common/error/UnauthorizedError.ts
@@ -1,0 +1,27 @@
+import { ResponseStatus } from './../../../ResponseStatus';
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class UnauthorizedError {
+  @ApiProperty({
+    type: 'number',
+    description: 'HTTP Error Code입니다.',
+    example: ResponseStatus.UN_AUTHORIZED,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Unauthorized',
+    description: 'Unauthorized',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Unauthorized',
+    example: 'Unauthorized',
+  })
+  data: string;
+}


### PR DESCRIPTION
## 작업사항
1. 입력값에서 deviceId를 받는 것에서, 이를 삭제하고 토큰으로 받게끔 변경
2. 컨트롤러에서 서비스로 넘어갈 때 dto -> Entity 변경이 아닌, 서비스 계층에서 Entity 변경

## 관계된 이슈, PR 
#56 