### PR TITLE
[fix]: 회원가입 성공 응답코드 변경 및 불필요한 로직 변경

### DIFF
--- a/apps/api/src/auth/AuthApiService.ts
+++ b/apps/api/src/auth/AuthApiService.ts
@@ -24,11 +24,7 @@ export class AuthApiService {
   ) {}
 
   async signup(signupUser: User): Promise<void> {
-    await this.create(signupUser);
-  }
-
-  async create(user: User): Promise<void> {
-    await this.userRepository.save(user);
+    await this.userRepository.save(signupUser);
   }
 
   async signin(signinUser: User): Promise<UserAccessToken> {

--- a/libs/common-config/src/response/ResponseEntity.ts
+++ b/libs/common-config/src/response/ResponseEntity.ts
@@ -30,11 +30,11 @@ export class ResponseEntity<T> {
   }
 
   static CREATED_WITH(message: string): ResponseEntity<string> {
-    return new ResponseEntity<string>(ResponseStatus.OK, message, '');
+    return new ResponseEntity<string>(ResponseStatus.CREATED, message, '');
   }
 
   static CREATED_WITH_DATA<T>(message: string, data: T): ResponseEntity<T> {
-    return new ResponseEntity<T>(ResponseStatus.OK, message, data);
+    return new ResponseEntity<T>(ResponseStatus.CREATED, message, data);
   }
 
   static NOT_FOUND(): ResponseEntity<string> {


### PR DESCRIPTION

## 작업사항
1. AuthApiService에서 signup과 create에 대한 로직을 나눴는데, 나누는 것이 테스트 코드를 작성할 때 불필요한 테스트 코드를 양산할 것이라 판단
2. 회원가입 성공 응답코드가 200으로 출력되는 문제 해결


## 관계된 이슈, PR 