### PR TITLE
[test]: UserApiService updateFcmToken 단위 테스트 추가

### DIFF
--- a/apps/api/src/auth/AuthApiService.ts
+++ b/apps/api/src/auth/AuthApiService.ts
@@ -8,7 +8,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { User } from '@app/entity/domain/user/User.entity';
-import { Repository, UpdateResult } from 'typeorm';
+import { Repository } from 'typeorm';
 import { UserApiRepository } from './../user/UserApiRepository';
 import { JwtService } from '@nestjs/jwt';
 import { UserId } from '@app/entity/domain/user/UserId';

--- a/apps/api/src/user/UserApiController.ts
+++ b/apps/api/src/user/UserApiController.ts
@@ -23,6 +23,7 @@ import { UnauthorizedError } from '@app/common-config/response/swagger/common/er
 import { BadRequestError } from '@app/common-config/response/swagger/common/error/BadRequestError';
 import { FcmTokenUpdateSuccess } from '@app/common-config/response/swagger/domain/user/FcmTokenUpdateSuccess';
 import { PushUpdateSuccess } from '@app/common-config/response/swagger/domain/user/pushUpdateSuccess';
+import { User } from '@app/entity/domain/user/User.entity';
 
 @Controller('user')
 @ApiTags('유저 API')
@@ -64,11 +65,18 @@ export class UserApiController {
     @Body() userUpdateFcmTokenDto: UserUpdateFcmTokenReq,
   ): Promise<ResponseEntity<string>> {
     try {
-      await this.userApiService.updateFcmToken(userUpdateFcmTokenDto, userDto);
+      await this.userApiService.updateFcmToken(
+        await User.updateFcmToken(
+          userUpdateFcmTokenDto.firebaseToken,
+          userDto.deviceId,
+        ),
+      );
       return ResponseEntity.OK_WITH('FCM 토큰 수정에 성공했습니다.');
     } catch (error) {
       this.logger.error(
-        `dto = ${JSON.stringify(userUpdateFcmTokenDto)}`,
+        `dto = ${JSON.stringify(userUpdateFcmTokenDto)}, ${JSON.stringify(
+          userDto,
+        )} `,
         error,
       );
       return ResponseEntity.ERROR_WITH('FCM 토큰 수정에 실패했습니다.');

--- a/apps/api/src/user/UserApiRepository.ts
+++ b/apps/api/src/user/UserApiRepository.ts
@@ -3,7 +3,10 @@ import { User } from '@app/entity/domain/user/User.entity';
 
 @EntityRepository(User)
 export class UserApiRepository extends Repository<User> {
-  async updateLoggedAtByDeviceId(loggedAt: Date, deviceId: string) {
+  async updateLoggedAtByDeviceId(
+    loggedAt: Date,
+    deviceId: string,
+  ): Promise<void> {
     const queryBuilder = createQueryBuilder()
       .update(User)
       .set({ loggedAt })
@@ -11,12 +14,15 @@ export class UserApiRepository extends Repository<User> {
     await queryBuilder.execute();
   }
 
-  async updateFirebaseToken(firebaseToken: string, deviceId: string) {
+  async updateFirebaseToken(
+    firebaseToken: string,
+    deviceId: string,
+  ): Promise<void> {
     const queryBuilder = createQueryBuilder()
       .update(User)
       .set({ firebaseToken })
       .where(`deviceId =:deviceId`, { deviceId });
-    return await queryBuilder.execute();
+    await queryBuilder.execute();
   }
 
   async updatePush(deviceId: string, isPush: boolean) {

--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -10,20 +10,11 @@ import { UserUpdatePushReq } from './dto/UserUpdatePushReq.dto';
 export class UserApiService {
   constructor(private readonly userApiRepository: UserApiRepository) {}
 
-  async updateFcmToken(
-    userUpdateFcmTokenDto: UserUpdateFcmTokenReq,
-    userDto: JwtPayload,
-  ): Promise<UpdateResult> {
-    const user: User = await User.updateFcmToken(
-      userUpdateFcmTokenDto.firebaseToken,
-      userDto.deviceId,
+  async updateFcmToken(updateFcmTokenUser: User): Promise<void> {
+    return await this.userApiRepository.updateFirebaseToken(
+      updateFcmTokenUser.firebaseToken,
+      updateFcmTokenUser.deviceId,
     );
-    const isUpdateFcmToken = await this.userApiRepository.updateFirebaseToken(
-      user.firebaseToken,
-      user.deviceId,
-    );
-    if (isUpdateFcmToken.affected === 0) throw new NotFoundException();
-    return isUpdateFcmToken;
   }
 
   async updatePush(

--- a/apps/api/test/unit/domain/user/UserApiService.spec.ts
+++ b/apps/api/test/unit/domain/user/UserApiService.spec.ts
@@ -1,20 +1,20 @@
-import { FavoriteModule } from '@app/entity/domain/favorite/FavoriteModule';
-import { ApiAppModule } from './../../../../src/ApiAppModule';
-import { Test, TestingModule } from '@nestjs/testing';
 import { UserApiService } from '../../../../src/user/UserApiService';
+import { UserApiRepositoryStub } from '../../stub/user/UserApiRepositoryStub';
+import { User } from '@app/entity/domain/user/User.entity';
 
 describe('UserApiService', () => {
-  let service: UserApiService;
+  let userApiRepository: UserApiRepositoryStub;
 
-  beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [FavoriteModule, ApiAppModule],
-    }).compile();
+  it('FCM 토큰 업데이트에 성공했습니다.', async () => {
+    // given
+    userApiRepository = new UserApiRepositoryStub();
 
-    service = module.get<UserApiService>(UserApiService);
-  });
-
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+    const sut = new UserApiService(userApiRepository);
+    // when
+    const actual = await sut.updateFcmToken(
+      await User.updateFcmToken('test', 'test213'),
+    );
+    // then
+    expect(actual).toBeUndefined();
   });
 });

--- a/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
+++ b/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
@@ -1,10 +1,7 @@
-import { User } from '@app/entity/domain/user/User.entity';
 import { UpdateResult } from '../../../../../../libs/entity/test/stub/UpdateResultStub';
 import { UserApiRepository } from '../../../../src/user/UserApiRepository';
 
 export class UserApiRepositoryStub extends UserApiRepository {
-  private _savedUser: User;
-
   constructor() {
     super();
   }
@@ -12,14 +9,9 @@ export class UserApiRepositoryStub extends UserApiRepository {
     await UpdateResult.updateLoggedAtByDeviceId();
     return;
   }
+
+  override async updateFirebaseToken(firebaseToken: string, deviceId: string) {
+    await UpdateResult.updateFirebaseToken();
+    return;
+  }
 }
-
-// export class UserApiRepositoryStub {
-//   private _savedUser: User;
-
-//   constructor() {}
-//   async updateLoggedAtByDeviceId(loggedAt: Date, deviceId: string) {
-//     await UpdateResult.updateLoggedAtByDeviceId();
-//     return;
-//   }
-// }

--- a/libs/entity/test/stub/UpdateResultStub.ts
+++ b/libs/entity/test/stub/UpdateResultStub.ts
@@ -10,4 +10,12 @@ export class UpdateResult {
     updateResult.affected = 1;
     return updateResult;
   }
+
+  static async updateFirebaseToken() {
+    const updateResult = new UpdateResult();
+    updateResult.generatedMaps = [];
+    updateResult.raw = [];
+    updateResult.affected = 1;
+    return updateResult;
+  }
 }


### PR DESCRIPTION
## 작업사항
1. UserApiService의 updateFcmToken 메서드 단위 테스트 추가
2. 서비스 계층에서 DTO -> Entity로 설정하는 것이 아닌, 컨트롤러 계층에서 Entity활용하는 로직으로 변경
3. UserApiRepository에서 불필요한 리턴 삭제
4. UserApiService의 updateFcmToken 메서드 불필요한 로직 제거
5. UserApiRepository의 updateFirebaseToken 메서드 Stub 객체 추가
6. updateFirebaseToken 메서드 Stub 객체의 성공 리턴 값 UpdateResultStub에 추가

## 관계된 이슈, PR 