### PR TITLE
[test]: UserApiService updatePush 단위 테스트 추가

### DIFF
--- a/apps/api/src/user/UserApiController.ts
+++ b/apps/api/src/user/UserApiController.ts
@@ -115,7 +115,9 @@ export class UserApiController {
     @Body() userUpdatePushDto: UserUpdatePushReq,
   ): Promise<ResponseEntity<string>> {
     try {
-      await this.userApiService.updatePush(userUpdatePushDto, userDto);
+      await this.userApiService.updatePush(
+        await User.updatePush(userDto.deviceId, userUpdatePushDto.isPush),
+      );
       return ResponseEntity.OK_WITH('푸시알림 허용 여부 수정에 성공했습니다.');
     } catch (error) {
       this.logger.error(`dto = ${JSON.stringify(userUpdatePushDto)}`, error);

--- a/apps/api/src/user/UserApiRepository.ts
+++ b/apps/api/src/user/UserApiRepository.ts
@@ -25,11 +25,11 @@ export class UserApiRepository extends Repository<User> {
     await queryBuilder.execute();
   }
 
-  async updatePush(deviceId: string, isPush: boolean) {
+  async updatePush(deviceId: string, isPush: boolean): Promise<void> {
     const queryBuilder = createQueryBuilder()
       .update(User)
       .set({ isPush })
       .where(`deviceId =:deviceId`, { deviceId });
-    return await queryBuilder.execute();
+    await queryBuilder.execute();
   }
 }

--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -1,34 +1,22 @@
-import { UserUpdateFcmTokenReq } from './dto/UserUpdateFcmTokenReq.dto';
 import { UserApiRepository } from './UserApiRepository';
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { UpdateResult } from 'typeorm';
+import { Injectable } from '@nestjs/common';
 import { User } from '@app/entity/domain/user/User.entity';
-import { JwtPayload } from '@app/common-config/jwt/JwtPayload';
-import { UserUpdatePushReq } from './dto/UserUpdatePushReq.dto';
 
 @Injectable()
 export class UserApiService {
   constructor(private readonly userApiRepository: UserApiRepository) {}
 
   async updateFcmToken(updateFcmTokenUser: User): Promise<void> {
-    return await this.userApiRepository.updateFirebaseToken(
+    await this.userApiRepository.updateFirebaseToken(
       updateFcmTokenUser.firebaseToken,
       updateFcmTokenUser.deviceId,
     );
   }
 
-  async updatePush(
-    UserUpdatePushDto: UserUpdatePushReq,
-    userDto: JwtPayload,
-  ): Promise<UpdateResult> {
-    const user: User = await User.updatePush(
-      userDto.deviceId,
-      UserUpdatePushDto.isPush,
+  async updatePush(updatePushUser: User): Promise<void> {
+    await this.userApiRepository.updatePush(
+      updatePushUser.deviceId,
+      updatePushUser.isPush,
     );
-    const isUpdatePush = await this.userApiRepository.updatePush(
-      user.deviceId,
-      user.isPush,
-    );
-    return isUpdatePush;
   }
 }

--- a/apps/api/test/unit/domain/user/UserApiService.spec.ts
+++ b/apps/api/test/unit/domain/user/UserApiService.spec.ts
@@ -10,10 +10,23 @@ describe('UserApiService', () => {
     userApiRepository = new UserApiRepositoryStub();
 
     const sut = new UserApiService(userApiRepository);
+
     // when
     const actual = await sut.updateFcmToken(
       await User.updateFcmToken('test', 'test213'),
     );
+    // then
+    expect(actual).toBeUndefined();
+  });
+
+  it('푸시알림 허용 여부 수정에 성공했습니다.', async () => {
+    // given
+    userApiRepository = new UserApiRepositoryStub();
+
+    const sut = new UserApiService(userApiRepository);
+
+    // when
+    const actual = await sut.updatePush(await User.updatePush('test', true));
     // then
     expect(actual).toBeUndefined();
   });

--- a/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
+++ b/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
@@ -6,12 +6,17 @@ export class UserApiRepositoryStub extends UserApiRepository {
     super();
   }
   override async updateLoggedAtByDeviceId(loggedAt: Date, deviceId: string) {
-    await UpdateResult.updateLoggedAtByDeviceId();
+    await UpdateResult.Result();
     return;
   }
 
   override async updateFirebaseToken(firebaseToken: string, deviceId: string) {
-    await UpdateResult.updateFirebaseToken();
+    await UpdateResult.Result();
+    return;
+  }
+
+  override async updatePush(deviceId: string, isPush: boolean) {
+    await UpdateResult.Result();
     return;
   }
 }

--- a/libs/entity/test/stub/UpdateResultStub.ts
+++ b/libs/entity/test/stub/UpdateResultStub.ts
@@ -1,21 +1,31 @@
 export class UpdateResult {
-  private generatedMaps: string[];
-  private raw: string[];
-  private affected: number;
+  private readonly _generatedMaps: string[];
+  private readonly _raw: string[];
+  private readonly _affected: number;
 
-  static async updateLoggedAtByDeviceId() {
-    const updateResult = new UpdateResult();
-    updateResult.generatedMaps = [];
-    updateResult.raw = [];
-    updateResult.affected = 1;
-    return updateResult;
+  private constructor(
+    generatedMaps: string[],
+    raw: string[],
+    affected: number,
+  ) {
+    this._generatedMaps = generatedMaps;
+    this._raw = raw;
+    this._affected = affected;
   }
 
-  static async updateFirebaseToken() {
-    const updateResult = new UpdateResult();
-    updateResult.generatedMaps = [];
-    updateResult.raw = [];
-    updateResult.affected = 1;
-    return updateResult;
+  get generatedMaps() {
+    return this._generatedMaps;
+  }
+
+  get raw() {
+    return this._raw;
+  }
+
+  get affected() {
+    return this._affected;
+  }
+
+  static async Result(): Promise<UpdateResult> {
+    return new UpdateResult([], [], 1);
   }
 }


### PR DESCRIPTION


## 작업사항
1. 서비스 계층에서 DTO -> Entity로 설정하는 것이 아닌, 컨트롤러 계층에서 Entity활용하는 로직으로 변경
2. UserApiService의 updatePush 메서드 불필요한 로직 제거
3. UserApiRepository에서 불필요한 리턴 삭제
4. UserApiRepository의 updatePush 메서드 Stub 객체 추가
5. Update 쿼리에서 Stub 객체에서 UpdateResult static 메서드를 계속 추가하던 것에서 하나만 생성해도 동작하도록 변경
6. UserApiService의 updatePush 메서드 단위 테스트 추가

## 관계된 이슈, PR 