### PR TITLE
[remove]: 불필요한 Table Relation Options 제거

### DIFF
--- a/libs/entity/migrations/1648471227763-cascade.ts
+++ b/libs/entity/migrations/1648471227763-cascade.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class cascade1648471227763 implements MigrationInterface {
+    name = 'cascade1648471227763'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "summoner_record" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "name" character varying NOT NULL, "tier" character varying, "win" integer NOT NULL, "lose" integer NOT NULL, "profile_icon_id" integer NOT NULL, "puuid" character varying NOT NULL, "summoner_id" character varying NOT NULL, "league_point" integer NOT NULL, "rank" character varying, CONSTRAINT "UQ_716eaabdfeca68d19b612ff783b" UNIQUE ("summoner_id"), CONSTRAINT "PK_cb1476b13c099b057573ec4a7ef" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "idx_summonerRecord_1" ON "summoner_record" ("summoner_id") `);
+        await queryRunner.query(`CREATE TABLE "user" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "user_id" character varying, "password" character varying, "device_id" character varying(50) NOT NULL, "is_push" boolean NOT NULL DEFAULT false, "firebase_token" character varying NOT NULL, "current_hashed_refresh_token" character varying, "logged_at" TIMESTAMP WITH TIME ZONE, CONSTRAINT "UQ_758b8ce7c18b9d347461b30228d" UNIQUE ("user_id"), CONSTRAINT "UQ_0232591a0b48e1eb92f3ec5d0d1" UNIQUE ("device_id"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "favorite_summoner" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "user_id" bigint NOT NULL, "summoner_id" character varying, CONSTRAINT "PK_757ccf78852f33ca1149fff4ca7" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "idx_favoriteSummoner_2" ON "favorite_summoner" ("summoner_id") `);
+        await queryRunner.query(`CREATE INDEX "idx_favoriteSummoner_1" ON "favorite_summoner" ("user_id") `);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_favoriteSummoner_1"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_favoriteSummoner_2"`);
+        await queryRunner.query(`DROP TABLE "favorite_summoner"`);
+        await queryRunner.query(`DROP TABLE "user"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_summonerRecord_1"`);
+        await queryRunner.query(`DROP TABLE "summoner_record"`);
+    }
+
+}

--- a/libs/entity/migrations/1648471701428-cascade.ts
+++ b/libs/entity/migrations/1648471701428-cascade.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class cascade1648471701428 implements MigrationInterface {
+    name = 'cascade1648471701428'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "summoner_record" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "name" character varying NOT NULL, "tier" character varying, "win" integer NOT NULL, "lose" integer NOT NULL, "profile_icon_id" integer NOT NULL, "puuid" character varying NOT NULL, "summoner_id" character varying NOT NULL, "league_point" integer NOT NULL, "rank" character varying, CONSTRAINT "UQ_716eaabdfeca68d19b612ff783b" UNIQUE ("summoner_id"), CONSTRAINT "PK_cb1476b13c099b057573ec4a7ef" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "idx_summonerRecord_1" ON "summoner_record" ("summoner_id") `);
+        await queryRunner.query(`CREATE TABLE "user" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "user_id" character varying, "password" character varying, "device_id" character varying(50) NOT NULL, "is_push" boolean NOT NULL DEFAULT false, "firebase_token" character varying NOT NULL, "current_hashed_refresh_token" character varying, "logged_at" TIMESTAMP WITH TIME ZONE, CONSTRAINT "UQ_758b8ce7c18b9d347461b30228d" UNIQUE ("user_id"), CONSTRAINT "UQ_0232591a0b48e1eb92f3ec5d0d1" UNIQUE ("device_id"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "favorite_summoner" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "user_id" bigint NOT NULL, "summoner_id" character varying, CONSTRAINT "PK_757ccf78852f33ca1149fff4ca7" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "idx_favoriteSummoner_2" ON "favorite_summoner" ("summoner_id") `);
+        await queryRunner.query(`CREATE INDEX "idx_favoriteSummoner_1" ON "favorite_summoner" ("user_id") `);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_favoriteSummoner_1"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_favoriteSummoner_2"`);
+        await queryRunner.query(`DROP TABLE "favorite_summoner"`);
+        await queryRunner.query(`DROP TABLE "user"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_summonerRecord_1"`);
+        await queryRunner.query(`DROP TABLE "summoner_record"`);
+    }
+
+}

--- a/libs/entity/src/domain/favoriteSummoner/FavoriteSummoner.entity.ts
+++ b/libs/entity/src/domain/favoriteSummoner/FavoriteSummoner.entity.ts
@@ -8,10 +8,7 @@ import { User } from '../user/User.entity';
 @Index('idx_favoriteSummoner_2', ['SummonerRecord'])
 export class FavoriteSummoner extends BaseTimeEntity {
   @ManyToOne(() => User, (user: User) => user.FavoriteSummoner, {
-    onDelete: 'SET NULL',
-    onUpdate: 'CASCADE',
     nullable: false,
-    eager: false,
   })
   @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
   User: User[] | User | number;
@@ -19,9 +16,6 @@ export class FavoriteSummoner extends BaseTimeEntity {
   @ManyToOne(
     () => SummonerRecord,
     (summonerRecord: SummonerRecord) => summonerRecord.FavoriteSummoner,
-    {
-      eager: true,
-    },
   )
   @JoinColumn({ name: 'summoner_id', referencedColumnName: 'summonerId' })
   SummonerRecord: SummonerRecord[] | SummonerRecord | string;

--- a/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
@@ -56,9 +56,6 @@ export class SummonerRecord extends BaseTimeEntity {
   @OneToMany(
     () => FavoriteSummoner,
     (favoriteSummoner: FavoriteSummoner) => favoriteSummoner.SummonerRecord,
-    {
-      eager: false,
-    },
   )
   FavoriteSummoner: FavoriteSummoner[];
 

--- a/libs/entity/src/domain/user/User.entity.ts
+++ b/libs/entity/src/domain/user/User.entity.ts
@@ -51,10 +51,6 @@ export class User extends BaseTimeEntity {
   @OneToMany(
     () => FavoriteSummoner,
     (favoriteSummoner: FavoriteSummoner) => favoriteSummoner.User,
-    {
-      eager: false,
-      onUpdate: 'CASCADE',
-    },
   )
   FavoriteSummoner: FavoriteSummoner[];
 


### PR DESCRIPTION
## 작업사항
1. queryBuilder를 활용하기에, eager, lazy 설정은 지금 당장은 불필요함.
2. onDelete의 경우 soft-delete를 활용하기에, Set Null, cascade 설정 또한 당장은 불필요함.
3. onUpdate의 경우 특정 업데이트를 할 때, 같이 업데이트 되어야 하는 테이블이 존재하지 않으므로 불필요한 설정

