### PR TITLE
[fix]: 즐겨찾기 테이블 Relation Option 수정

### DIFF
--- a/libs/entity/migrations/1648472915730-cascade.ts
+++ b/libs/entity/migrations/1648472915730-cascade.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class cascade1648472915730 implements MigrationInterface {
+    name = 'cascade1648472915730'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/libs/entity/migrations/1648473321481-cascade.ts
+++ b/libs/entity/migrations/1648473321481-cascade.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class cascade1648473321481 implements MigrationInterface {
+    name = 'cascade1648473321481'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" DROP CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7"`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_01a5ec5c7c4f7121f4afe85ff23" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "favorite_summoner" ADD CONSTRAINT "FK_cc85ee2ad134fcc7c77eced37c7" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/libs/entity/src/domain/favoriteSummoner/FavoriteSummoner.entity.ts
+++ b/libs/entity/src/domain/favoriteSummoner/FavoriteSummoner.entity.ts
@@ -8,6 +8,8 @@ import { User } from '../user/User.entity';
 @Index('idx_favoriteSummoner_2', ['SummonerRecord'])
 export class FavoriteSummoner extends BaseTimeEntity {
   @ManyToOne(() => User, (user: User) => user.FavoriteSummoner, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
     nullable: false,
   })
   @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
@@ -16,6 +18,10 @@ export class FavoriteSummoner extends BaseTimeEntity {
   @ManyToOne(
     () => SummonerRecord,
     (summonerRecord: SummonerRecord) => summonerRecord.FavoriteSummoner,
+    {
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
   )
   @JoinColumn({ name: 'summoner_id', referencedColumnName: 'summonerId' })
   SummonerRecord: SummonerRecord[] | SummonerRecord | string;


### PR DESCRIPTION
## 작업사항
- Test의 편의상, 부모 테이블의 데이터가 삭제될 경우 자식 테이블의 데이터도 삭제, 수정되게끔 cascade 설정
