### PR TITLE
[feat]: 즐겨찾기 추가, 취소 API 호출 시, Redis에 summonerId 관리 로직 구성

### DIFF
--- a/libs/entity/test/stub/RedisStub.ts
+++ b/libs/entity/test/stub/RedisStub.ts
@@ -18,4 +18,7 @@ export class RedisStub {
   async exec(): Promise<boolean> {
     return null;
   }
+
+  async srem(): Promise<void> {}
+  async sadd(): Promise<void> {}
 }


### PR DESCRIPTION


## 작업사항
1. 즐겨찾기 추가 API 호출 시, Redis Set 자료구조 방식으로, summonerId를 키로 하고, 값으로 입력받은 summonerId를 구성
2. 즐겨찾기 취소 API 호출 시, 아무도 즐겨찾기 하지 않는 사용자는 summonerId를 Set 키에서 제거하는 로직 구성
3. sadd, srem stub 로직 추가

## 관계된 이슈, PR 
#118 