### PR TITLE
[feat]: Riot API와 비교해서, 전적이 변동됐을 때 로직 구성

### DIFF
--- a/apps/push/src/push/PushApiConsumer.ts
+++ b/apps/push/src/push/PushApiConsumer.ts
@@ -2,12 +2,12 @@ import { Process, Processor } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 
-@Processor('testQueue')
+@Processor('PushQueue')
 export class PushApiConsumer {
   private readonly logger = new Logger(PushApiConsumer.name);
 
-  @Process('task')
-  getMessageQueue(job: Job) {
+  @Process('summonerList')
+  getSummonerIdQueue(job: Job) {
     this.logger.log(`${job.id} 번 작업을 수신했습니다.`);
   }
 }

--- a/apps/push/src/push/PushApiController.ts
+++ b/apps/push/src/push/PushApiController.ts
@@ -1,6 +1,5 @@
 import { ResponseEntity } from '@app/common-config/response/ResponseEntity';
-import { Body, Controller, Get, Inject, Post } from '@nestjs/common';
-import { Job } from 'bull';
+import { Controller, Get, Inject } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { PushApiService } from './PushApiService';
@@ -12,27 +11,14 @@ export class PushApiController {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger,
   ) {}
 
-  @Post('queue')
-  async addMessage(
-    @Body() data: number,
-  ): Promise<ResponseEntity<Job | string>> {
+  @Get('queue')
+  async addMessage(): Promise<ResponseEntity<string>> {
     try {
-      const res = await this.pushApiService.addMessageQueue(data);
-      return ResponseEntity.OK_WITH_DATA('메시지 전송에 성공했습니다.', res);
-    } catch (error) {
-      this.logger.error(`dto = ${JSON.stringify(data)}`, error);
-      return ResponseEntity.ERROR_WITH('메시지 전송에 실패했습니다.');
-    }
-  }
-
-  @Get('cache')
-  async getCache(): Promise<ResponseEntity<string>> {
-    try {
-      const res = await this.pushApiService.cacheTest();
-      return ResponseEntity.OK_WITH_DATA('캐시 테스트에 성공했습니다.', res);
+      await this.pushApiService.addMessageQueue();
+      return ResponseEntity.OK_WITH('메시지 전송에 성공했습니다.');
     } catch (error) {
       this.logger.error(error);
-      return ResponseEntity.ERROR_WITH('캐시 테스트에 실패했습니다.');
+      return ResponseEntity.ERROR_WITH('메시지 전송에 실패했습니다.');
     }
   }
 }

--- a/apps/push/src/push/PushApiModule.ts
+++ b/apps/push/src/push/PushApiModule.ts
@@ -5,11 +5,14 @@ import { PushApiController } from './PushApiController';
 import { PushApiService } from './PushApiService';
 import { getBullQueue } from '../../../../libs/entity/queue/getBullQueue';
 import { PushApiConsumer } from './PushApiConsumer';
+import { RedisModule } from 'nestjs-redis';
+import { RedisModuleConfig } from '../../../../libs/entity/config/redisConfig';
 
 @Module({
   imports: [
     WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'push')),
     getBullQueue(),
+    RedisModule.register(RedisModuleConfig),
   ],
   controllers: [PushApiController],
   providers: [PushApiService, PushApiConsumer],

--- a/apps/push/src/push/dto/PushRiotApi.ts
+++ b/apps/push/src/push/dto/PushRiotApi.ts
@@ -1,0 +1,23 @@
+import { Exclude, Expose } from 'class-transformer';
+
+export class PushRiotApi {
+  @Exclude() leagueId: string;
+  @Exclude() queueType: string;
+  @Exclude() rank: string;
+  @Exclude() summonerId: string;
+  @Exclude() summonerName: string;
+  @Exclude() leaguePoints: number;
+  @Exclude() veteran: boolean;
+  @Exclude() freshBlood: boolean;
+  @Exclude() hotStreak: boolean;
+  @Exclude() inactive: boolean;
+
+  @Expose({ name: 'wins' })
+  win: number;
+
+  @Expose({ name: 'losses' })
+  lose: number;
+
+  @Expose({ name: 'tier' })
+  tier: string;
+}

--- a/libs/entity/queue/getBullQueue.ts
+++ b/libs/entity/queue/getBullQueue.ts
@@ -2,6 +2,6 @@ import { BullModule } from '@nestjs/bull';
 
 export function getBullQueue() {
   return BullModule.registerQueue({
-    name: 'testQueue',
+    name: 'PushQueue',
   });
 }

--- a/libs/entity/queue/src/bull-monitor/BullMonitorService.ts
+++ b/libs/entity/queue/src/bull-monitor/BullMonitorService.ts
@@ -6,7 +6,7 @@ import { BullAdapter } from '@bull-monitor/root/dist/bull-adapter';
 
 @Injectable()
 export class BullMonitorService extends BullMonitorExpress {
-  constructor(@InjectQueue('testQueue') testQueue: Queue) {
-    super({ queues: [new BullAdapter(testQueue)] });
+  constructor(@InjectQueue('PushQueue') pushQueue: Queue) {
+    super({ queues: [new BullAdapter(pushQueue)] });
   }
 }

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,6 +1,6 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "apps/api/src",
+  "sourceRoot": "apps/push/src",
   "monorepo": true,
   "projects": {
     "entity": {


### PR DESCRIPTION
## 작업사항
1. pushQueue에 EnQueue 작업 추가
2. 현재 Redis의 기록과 Riot API의 기록을 비교하는 로직 추가
3. 기록이 변경됐으면, Riot API에서 얻은 데이터를 Redis 기록에 수정하는 로직 추가
4. Queue 내용 추가
5. 불필요한 로직 제거

## 관계된 이슈, PR 
#119 #114 