### PR TITLE
[feat]: Redis 장애 복구 API 추가

### DIFF
--- a/apps/api/src/summonerRecord/SummonerRecordApiQueryRepository.ts
+++ b/apps/api/src/summonerRecord/SummonerRecordApiQueryRepository.ts
@@ -2,6 +2,7 @@ import { plainToInstance } from 'class-transformer';
 import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
 import { SummonerRecordId } from '@app/entity/domain/summonerRecord/SummonerRecordId';
+import { SummonerRecordSummonerId } from '@app/entity/domain/summonerRecord/SummonerRecordSummonerId';
 
 @EntityRepository(SummonerRecord)
 export class SummonerRecordApiQueryRepository extends Repository<SummonerRecord> {
@@ -19,6 +20,11 @@ export class SummonerRecordApiQueryRepository extends Repository<SummonerRecord>
     return plainToInstance(SummonerRecordId, row);
   }
 
+  async findAllSummonerRecordId(): Promise<SummonerRecordSummonerId[]> {
+    const row = await this.findAllSummonerId();
+    return plainToInstance(SummonerRecordSummonerId, row);
+  }
+
   private async findOneBySummonerId(summonerId: string) {
     const queryBuilder = createQueryBuilder()
       .select(['id'])
@@ -34,5 +40,13 @@ export class SummonerRecordApiQueryRepository extends Repository<SummonerRecord>
       .from(SummonerRecord, 'summonerRecord')
       .where(`summonerRecord.summonerId =:summonerId`, { summonerId });
     return await queryBuilder.getRawOne();
+  }
+
+  private async findAllSummonerId() {
+    const queryBuilder = createQueryBuilder()
+      .select(['summoner_id'])
+      .from(SummonerRecord, 'summonerRecord');
+
+    return await queryBuilder.getRawMany();
   }
 }

--- a/apps/push/src/push/PushApiConsumer.ts
+++ b/apps/push/src/push/PushApiConsumer.ts
@@ -1,17 +1,41 @@
+import { PushApiService } from './PushApiService';
 import { PushJobService } from './../../../../libs/common-config/src/job/src/PushJobService';
 import { Process, Processor } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
+import { plainToInstance } from 'class-transformer';
+import { RiotApiJobs } from '@app/common-config/job/RiotApi';
+import { PushRiotApi } from './dto/PushRiotApi';
 
 @Processor('PushQueue')
 export class PushApiConsumer {
   private readonly logger = new Logger(PushApiConsumer.name);
 
-  constructor(private readonly pushJobService: PushJobService) {}
+  constructor(
+    private readonly pushJobService: PushJobService,
+    private readonly pushApiService: PushApiService,
+  ) {}
 
   @Process('summonerList')
   async getSummonerIdQueue(job: Job) {
     await this.pushJobService.send(job.data['summonerId']);
     this.logger.log(`${job.data['summonerId']} topic 푸시를 전송했습니다.`);
+  }
+
+  @Process('recoverList')
+  async getRecoverQueue(job: Job) {
+    const redisClient = await this.pushApiService.getRedisClient();
+    const riotApiResponse = plainToInstance(
+      PushRiotApi,
+      await RiotApiJobs(job.data['summonerId']),
+    );
+    await this.pushApiService.changeRecord(
+      riotApiResponse,
+      redisClient,
+      job.data['summonerId'],
+    );
+
+    await this.pushApiService.addRedisSet(redisClient, job.data['summonerId']);
+    this.logger.log(`${job.data}를 Redis에 추가했습니다.`);
   }
 }

--- a/apps/push/src/push/PushApiController.ts
+++ b/apps/push/src/push/PushApiController.ts
@@ -1,5 +1,5 @@
 import { ResponseEntity } from '@app/common-config/response/ResponseEntity';
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get, Inject, Post } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { PushApiService } from './PushApiService';
@@ -19,6 +19,17 @@ export class PushApiController {
     } catch (error) {
       this.logger.error(error);
       return ResponseEntity.ERROR_WITH('메시지 전송에 실패했습니다.');
+    }
+  }
+
+  @Post('redis')
+  async addRedis(): Promise<ResponseEntity<string>> {
+    try {
+      await this.pushApiService.recoverRedis();
+      return ResponseEntity.OK_WITH('Redis에 데이터 추가를 성공했습니다.');
+    } catch (error) {
+      this.logger.error(error);
+      return ResponseEntity.ERROR_WITH('Redis에 데이터 추가를 실패했습니다.');
     }
   }
 }

--- a/apps/push/src/push/PushApiModule.ts
+++ b/apps/push/src/push/PushApiModule.ts
@@ -1,3 +1,4 @@
+import { SummonerRecordApiModule } from './../../../api/src/summonerRecord/SummonerRecordApiModule';
 import { PushJobModule } from './../../../../libs/common-config/src/job/src/PushJobModule';
 import { Module } from '@nestjs/common';
 import { WinstonModule } from 'nest-winston';
@@ -17,6 +18,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     getBullQueue(),
     RedisModule.register(RedisModuleConfig),
     ScheduleModule.forRoot(),
+    SummonerRecordApiModule,
   ],
   controllers: [PushApiController],
   providers: [PushApiService, PushApiConsumer],

--- a/libs/entity/src/domain/summonerRecord/SummonerRecordSummonerId.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecordSummonerId.ts
@@ -1,0 +1,12 @@
+import { Expose } from 'class-transformer';
+
+export class SummonerRecordSummonerId {
+  @Expose({ name: 'summoner_id' })
+  summonerId: string;
+
+  static from(summonerId: string): SummonerRecordSummonerId {
+    const dto = new SummonerRecordSummonerId();
+    dto.summonerId = summonerId;
+    return dto;
+  }
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,6 +1,6 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "apps/api/src",
+  "sourceRoot": "apps/push/src",
   "monorepo": true,
   "projects": {
     "entity": {


### PR DESCRIPTION

## 작업사항
1. Redis 서버 장애 시, 데이터가 모두 사라질 경우를 대비해서, RDS를 활용하여 Redis에 데이터를 추가하는 작업 로직 추가


## 관계된 이슈, PR 
#115 