### PR TITLE
[fix]: nestjs-redis 라이브러리 삭제로 인한 단위테스트 로직 수정

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
@@ -16,7 +16,7 @@ import { FavoriteSummonerIdReq } from './dto/FavoriteSummonerIdReq.dto';
 import { FavoriteSummonerId } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerId';
 import { User } from '@app/entity/domain/user/User.entity';
 import { FavoriteSummonerRes } from './dto/FavoriteSummonerRes.dto';
-import { RedisModuleConfig } from 'libs/entity/config/redisConfig';
+import { RedisModuleConfig } from '../../../../libs/entity/config/redisConfig';
 
 import Redis from 'ioredis';
 

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -14,7 +14,6 @@ describe('FavoriteSummonerApiService', () => {
   let summonerRecordRepository;
   let summonerRecordApiQueryRepository: SummonerRecordApiQueryRepositoryStub;
   let favoriteSummonerApiQueryRepository: FavoriteSummonerApiQueryRepositoryStub;
-  let redisService;
 
   it('즐겨찾기 추가에 성공했습니다.', async () => {
     // given
@@ -24,14 +23,12 @@ describe('FavoriteSummonerApiService', () => {
       new SummonerRecordApiQueryRepositoryStub();
     favoriteSummonerApiQueryRepository =
       new FavoriteSummonerApiQueryRepositoryStub();
-    redisService = new RedisServiceStub();
 
     const sut = new FavoriteSummonerApiService(
       favoriteSummonerRepository,
       summonerRecordRepository,
       summonerRecordApiQueryRepository,
       favoriteSummonerApiQueryRepository,
-      redisService,
     );
     // when
     const actual = await sut.createFavoriteSummoner(
@@ -98,14 +95,12 @@ describe('FavoriteSummonerApiService', () => {
       new SummonerRecordApiQueryRepositoryStub();
     favoriteSummonerApiQueryRepository =
       new FavoriteSummonerApiQueryRepositoryStub();
-    redisService = new RedisServiceStub();
 
     const sut = new FavoriteSummonerApiService(
       favoriteSummonerRepository,
       summonerRecordRepository,
       summonerRecordApiQueryRepository,
       favoriteSummonerApiQueryRepository,
-      redisService,
     );
     // when
     const actual = await sut.deleteFavoriteSummoner(


### PR DESCRIPTION

## 작업사항
1. redisService를 주입받는 것이 삭제되었으므로, 단위테스트에서도 삭제시켜줘야함.


## 관계된 이슈, PR 