### PR TITLE
[HOTFIX]: 솔로 랭크 경기 전적에 맞게만 푸시 알림을 보내게끔 변경

### DIFF
--- a/libs/common-config/src/job/RiotApi.ts
+++ b/libs/common-config/src/job/RiotApi.ts
@@ -9,5 +9,10 @@ export const RiotApiJobs = async (summonerId: string) => {
   const url = `https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/${summonerId}?api_key=${api_key}`;
 
   const res = await axios.get(url);
-  return res.data[0];
+
+  for (let i = 0; i < res.data.length; i++) {
+    if (res.data[i]['queueType'] === 'RANKED_SOLO_5x5') {
+      return res.data[i];
+    }
+  }
 };


### PR DESCRIPTION

## 작업사항
1. 기존에는 솔로 랭크 전적의 데이터만 다루지 않았던 문제가 있었음.
2. 급한 문제 해결하고 코드에서 나는 악취를 해결할 예정


## 관계된 이슈, PR 