### PR TITLE
[HOTFIX]: 솔로 랭크 전적이 없는 경우, 로직 변경

### DIFF
--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -25,11 +25,10 @@ export class PushApiService {
     const summonerIds = await redisClient.smembers('summonerId');
 
     summonerIds.map(async summonerId => {
-      const riotApiResponse = plainToInstance(
-        PushRiotApi,
-        await RiotApiJobService.riotLeagueApi(summonerId),
-      );
+      const soloRankResult = await RiotApiJobService.riotLeagueApi(summonerId);
+      if (!soloRankResult) return;
 
+      const riotApiResponse = plainToInstance(PushRiotApi, soloRankResult);
       const redisResponse = await redisClient.mget(
         `summonerId:${summonerId}:win`,
         `summonerId:${summonerId}:lose`,
@@ -66,6 +65,7 @@ export class PushApiService {
     redisResponse: string[],
   ): Promise<boolean> {
     const [win, lose, tier] = redisResponse;
+    if (riotApiResponse == undefined) return false;
     if (riotApiResponse.tier !== tier) return true;
     if (riotApiResponse.win !== Number(win)) return true;
     if (riotApiResponse.lose !== Number(lose)) return true;

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -65,7 +65,6 @@ export class PushApiService {
     redisResponse: string[],
   ): Promise<boolean> {
     const [win, lose, tier] = redisResponse;
-    if (riotApiResponse == undefined) return false;
     if (riotApiResponse.tier !== tier) return true;
     if (riotApiResponse.win !== Number(win)) return true;
     if (riotApiResponse.lose !== Number(lose)) return true;

--- a/libs/common-config/src/job/riot/RiotApiJobService.ts
+++ b/libs/common-config/src/job/riot/RiotApiJobService.ts
@@ -3,13 +3,14 @@ import axios from 'axios';
 
 @Injectable()
 export class RiotApiJobService {
-  static async riotLeagueApi(summonerId: string) {
+  static async riotLeagueApi(summonerId: string): Promise<any> {
     const url = `https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/${summonerId}?api_key=${process.env.API_KEY}`;
 
     const res = await axios.get(url);
 
-    return res.data.filter(
+    const soloRankResult = res.data.filter(
       riotApiReturn => riotApiReturn['queueType'] === 'RANKED_SOLO_5x5',
     );
+    return soloRankResult.length === 0 ? false : soloRankResult;
   }
 }


### PR DESCRIPTION
## 문제사항
1. RANKED_SOLO_5x5 전적이 있는 경우의 데이터만 필터링해서 사용했는데, RANKED_SOLO_5x5 전적이 없는 경우 필터링할 데이터가 없으므로 빈 배열의 응답을 전달했음.
2. 빈 배열을 받을 경우, 처리하는 로직이 없었기에, 푸시 알림이 지속적으로 전달됐던 문제가 발생.

## 작업사항
1. 다른 경기 전적들은 있지만, 솔로 랭크 경기 전적만 없는 경우를 처리하는 로직 추가

