### PR TITLE
[fix]: 회원가입 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+env/*

--- a/apps/api/src/auth/AuthApiController.ts
+++ b/apps/api/src/auth/AuthApiController.ts
@@ -1,11 +1,10 @@
+import { SignupFailV1 } from './../../../../libs/common-config/src/response/swagger/domain/auth/SignupFailV1';
 import { UserAccessToken } from '@app/entity/domain/user/UserAccessToken';
 import { SigninFail } from '@app/common-config/response/swagger/domain/auth/SigninFail';
 import { SigninSuccess } from '@app/common-config/response/swagger/domain/auth/SigninSuccess';
 import { ResponseEntity } from '@app/common-config/response/ResponseEntity';
 import { ResponseStatus } from '@app/common-config/response/ResponseStatus';
-import { Body, Controller, HttpCode, Inject, Post } from '@nestjs/common';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import { Logger } from 'winston';
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
 import { AuthApiService } from './AuthApiService';
 import {
   ApiOperation,
@@ -15,20 +14,19 @@ import {
   ApiTags,
   ApiOkResponse,
   ApiNotFoundResponse,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 import { BadRequestError } from '@app/common-config/response/swagger/common/error/BadRequestError';
 import { SignupFail } from '@app/common-config/response/swagger/domain/auth/SignupFail';
 import { AuthSigninReq, AuthSignupReq } from './dto';
 import { SignupSuccess } from '@app/common-config/response/swagger/domain/auth/SignupSuccess';
 import { SigninNotFoundFail } from '@app/common-config/response/swagger/domain/auth/SigninNotFoundFail';
+import { SignupUnprocessableEntityFail } from '@app/common-config/response/swagger/domain/auth/SignupUnprocessableEntityFail';
 
 @Controller('auth')
 @ApiTags('회원가입, 로그인 API')
 export class AuthApiController {
-  constructor(
-    private readonly authApiService: AuthApiService,
-    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger,
-  ) {}
+  constructor(private readonly authApiService: AuthApiService) {}
 
   @ApiOperation({
     summary: '회원 가입',
@@ -55,9 +53,37 @@ export class AuthApiController {
       await this.authApiService.signup(await dto.toEntity());
       return ResponseEntity.CREATED_WITH('회원 가입에 성공했습니다.');
     } catch (error) {
-      this.logger.error(`dto = ${JSON.stringify(dto)}`, error);
       return ResponseEntity.ERROR_WITH('회원 가입에 실패했습니다.');
     }
+  }
+
+  @ApiOperation({
+    summary: '회원 가입 V1',
+    description: `
+    회원 가입할 때 deviceId, firebaseToken을 입력받습니다. \n
+    회원 가입할 때 입력값을 누락한 경우 에러를 출력합니다. \n
+    `,
+  })
+  @ApiCreatedResponse({
+    description: '회원 가입에 성공했습니다.',
+    type: SignupSuccess,
+  })
+  @ApiBadRequestResponse({
+    description: '입력값을 누락한 경우 입니다.',
+    type: BadRequestError,
+  })
+  @ApiUnprocessableEntityResponse({
+    description: '이미 DB에 있는 deviceId를 입력했습니다.',
+    type: SignupUnprocessableEntityFail,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '회원 가입에 실패했습니다. 실제 응답 코드는 201을 받습니다.',
+    type: SignupFailV1,
+  })
+  @Post('/signup/v1')
+  async signupV1(@Body() dto: AuthSignupReq): Promise<ResponseEntity<string>> {
+    await this.authApiService.signupV1(await dto.toEntity());
+    return ResponseEntity.CREATED_WITH('회원 가입에 성공했습니다.');
   }
 
   @ApiOperation({
@@ -92,7 +118,6 @@ export class AuthApiController {
         userId,
       );
     } catch (error) {
-      this.logger.error(`dto = ${JSON.stringify(dto)}`, error);
       if (error.status === ResponseStatus.NOT_FOUND)
         return ResponseEntity.NOT_FOUND_WITH(error.message);
       return ResponseEntity.ERROR_WITH('로그인에 실패했습니다.');

--- a/libs/common-config/src/response/ResponseStatus.ts
+++ b/libs/common-config/src/response/ResponseStatus.ts
@@ -7,6 +7,7 @@ export const ResponseStatus = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   UN_AUTHORIZED: 401,
+  UNPROCESSABLE: 422,
 } as const;
 
 export type ResponseStatus = typeof ResponseStatus[keyof typeof ResponseStatus];

--- a/libs/common-config/src/response/swagger/common/error/UnprocessableEntityError.ts
+++ b/libs/common-config/src/response/swagger/common/error/UnprocessableEntityError.ts
@@ -1,0 +1,29 @@
+import { ResponseStatus } from '@app/common-config/response/ResponseStatus';
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class UnprocessableEntityError {
+  @ApiProperty({
+    type: 'number',
+    description: 'HTTP Error Code입니다.',
+    example: ResponseStatus.UNPROCESSABLE,
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example:
+      '서버가 요청을 이해하고 요청 문법도 올바르지만 요청된 지시를 따를 수 없음을 나타냅니다.',
+    description:
+      '서버가 요청을 이해하고 요청 문법도 올바르지만 요청된 지시를 따를 수 없음을 나타냅니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: '응답 데이터',
+    example: '',
+  })
+  data: string;
+}

--- a/libs/common-config/src/response/swagger/domain/auth/SignupFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/auth/SignupFailV1.ts
@@ -1,0 +1,23 @@
+import { InternalServerError } from '../../common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class SignupFailV1 extends PickType(InternalServerError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '회원 가입 로직이 실패했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '회원 가입 로직이 실패했습니다.',
+  })
+  data: string;
+}

--- a/libs/common-config/src/response/swagger/domain/auth/SignupUnprocessableEntityFail.ts
+++ b/libs/common-config/src/response/swagger/domain/auth/SignupUnprocessableEntityFail.ts
@@ -1,0 +1,24 @@
+import { UnprocessableEntityError } from './../../common/error/UnprocessableEntityError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class SignupUnprocessableEntityFail extends PickType(
+  UnprocessableEntityError,
+  ['statusCode'] as const,
+) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    description: 'Unprocessable Entity',
+    example: 'Unprocessable Entity',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    description: '이미 DB에 있는 deviceId를 입력했습니다.',
+    example: '이미 DB에 있는 deviceId를 입력했습니다.',
+  })
+  data: string;
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,6 +1,6 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "apps/push/src",
+  "sourceRoot": "apps/api/src",
   "monorepo": true,
   "projects": {
     "entity": {


### PR DESCRIPTION

## 작업사항
- 회원가입 API 에러를 핸들링하는 로직을 추가한 API를 새롭게 생성

## 추후 작업 예정 사항
1. 클라이언트 강제 업데이트 로직이 완성되면, 새로 추가된 회원가입 API는 삭제될 예정
2. 회원가입 뿐 아니라 다른 API의 에러 처리 로직을 모두 변경할 예정
3. 현재 API의 에러 처리 로직에서, 컨트롤러에서 try-catch를 사용할 필요가 없어보임. 에러를 전역적으로 처리하는 것으로 변경하려 함.
4. controller - service - repository의 계층분리 상태에서, service 계층에서 에러를 핸들링 하는 것이 비즈니스 로직이 다른 계층을 침범하는 문제를 해결할 수 있다고 생각함
5. 현재 만약 controller에서 try-catch로 에러를 처리하면, 비즈니스 로직이 컨트롤러까지 들어가는 상황이기에 이 부분을 추후 변경할 예정


## 관계된 이슈, PR 
#146 