### PR TITLE
[fix]: 로그인 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/apps/api/src/auth/AuthApiController.ts
+++ b/apps/api/src/auth/AuthApiController.ts
@@ -1,3 +1,5 @@
+import { SigninNotFoundFailV1 } from './../../../../libs/common-config/src/response/swagger/domain/auth/SigninNotFoundFailV1';
+import { SigninFailV1 } from './../../../../libs/common-config/src/response/swagger/domain/auth/SigninFailV1';
 import { SignupFailV1 } from './../../../../libs/common-config/src/response/swagger/domain/auth/SignupFailV1';
 import { UserAccessToken } from '@app/entity/domain/user/UserAccessToken';
 import { SigninFail } from '@app/common-config/response/swagger/domain/auth/SigninFail';
@@ -77,7 +79,7 @@ export class AuthApiController {
     type: SignupUnprocessableEntityFail,
   })
   @ApiInternalServerErrorResponse({
-    description: '회원 가입에 실패했습니다. 실제 응답 코드는 201을 받습니다.',
+    description: '회원 가입에 실패했습니다.',
     type: SignupFailV1,
   })
   @Post('/signup/v1')
@@ -122,5 +124,37 @@ export class AuthApiController {
         return ResponseEntity.NOT_FOUND_WITH(error.message);
       return ResponseEntity.ERROR_WITH('로그인에 실패했습니다.');
     }
+  }
+
+  @ApiOperation({
+    summary: '로그인 V1',
+    description: `
+    로그인할 때 deviceId를 입력받습니다. \n
+    로그인할 때 입력값을 누락한 경우 400 에러를 출력합니다. \n
+    로그인할 때 deviceId가 DB에 저장되어 있지 않다면 404 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '로그인에 성공했습니다.',
+    type: SigninSuccess,
+  })
+  @ApiNotFoundResponse({
+    description: '입력한 deviceId는 DB에 저장되어 있지 않습니다.',
+    type: SigninNotFoundFailV1,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '로그인에 실패했습니다.',
+    type: SigninFailV1,
+  })
+  @HttpCode(ResponseStatus.OK)
+  @Post('/signin/v1')
+  async signinV1(
+    @Body() dto: AuthSigninReq,
+  ): Promise<ResponseEntity<UserAccessToken | string>> {
+    const userId = await this.authApiService.signinV1(await dto.toEntity());
+    return ResponseEntity.OK_WITH_DATA<UserAccessToken>(
+      '로그인에 성공했습니다.',
+      userId,
+    );
   }
 }

--- a/apps/api/src/auth/AuthApiService.ts
+++ b/apps/api/src/auth/AuthApiService.ts
@@ -59,6 +59,26 @@ export class AuthApiService {
     return { accessToken: this.jwtService.sign(payload) };
   }
 
+  async signinV1(signinUser: User): Promise<UserAccessToken> {
+    try {
+      const foundUserId = await this.findUserByDeviceId(signinUser.deviceId);
+      if (!foundUserId)
+        throw new NotFoundException('입력된 deviceId가 존재하지 않습니다.');
+      await this.updateLoggedAt(signinUser.loggedAt, signinUser.deviceId);
+      const payload: JwtPayload = {
+        userId: foundUserId.id,
+        deviceId: signinUser.deviceId,
+      };
+      return { accessToken: this.jwtService.sign(payload) };
+    } catch (error) {
+      this.logger.error(`dto = ${JSON.stringify(signinUser)}`, error);
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException('입력된 deviceId가 존재하지 않습니다.');
+      }
+      throw new InternalServerErrorException();
+    }
+  }
+
   async validateUser(payload: JwtPayload): Promise<JwtPayload> {
     const { deviceId } = payload;
     const user: UserId = await this.findUserByDeviceId(deviceId);

--- a/libs/common-config/src/response/swagger/domain/auth/SigninFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/auth/SigninFailV1.ts
@@ -1,0 +1,23 @@
+import { InternalServerError } from '../../common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class SigninFailV1 extends PickType(InternalServerError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '로그인 로직이 실패했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '로그인 로직이 실패했습니다.',
+  })
+  data: string;
+}

--- a/libs/common-config/src/response/swagger/domain/auth/SigninNotFoundFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/auth/SigninNotFoundFailV1.ts
@@ -1,0 +1,23 @@
+import { NotFoundError } from '@app/common-config/response/swagger/common/error/NotFoundError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class SigninNotFoundFailV1 extends PickType(NotFoundError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: '입력된 deviceId가 존재하지 않습니다.',
+    description: '입력된 deviceId가 존재하지 않습니다.',
+  })
+  data: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Not Found',
+    description: '입력된 deviceId가 존재하지 않습니다.',
+  })
+  message: string;
+}


### PR DESCRIPTION
## 작업사항
- 로그인 API 에러를 핸들링하는 로직을 추가한 API를 새롭게 생성

## 추후 작업 예정 사항
1. 클라이언트 강제 업데이트 로직이 완성되면, 새로 추가된 로그인 API는 삭제될 예정
2. 회원가입, 로그인 뿐 아니라 다른 API의 에러 처리 로직을 모두 변경할 예정
3. 현재 API의 에러 처리 로직에서, 컨트롤러에서 try-catch를 사용할 필요가 없어보임. 에러를 전역적으로 처리하는 것으로 변경하려 함.
4. controller - service - repository의 계층분리 상태에서, service 계층에서 에러를 핸들링 하는 것이 비즈니스 로직이 다른 계층을 침범하는 문제를 해결할 수 있다고 생각함
5. 현재 만약 controller에서 try-catch로 에러를 처리하면, 비즈니스 로직이 컨트롤러까지 들어가는 상황이기에 이 부분을 추후 변경할 예정

## 관계된 이슈, PR
#146