### PR TITLE
[fix]: 푸시허용 여부 변경 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/apps/api/src/user/UserApiController.ts
+++ b/apps/api/src/user/UserApiController.ts
@@ -23,6 +23,7 @@ import { UnauthorizedError } from '@app/common-config/response/swagger/common/er
 import { BadRequestError } from '@app/common-config/response/swagger/common/error/BadRequestError';
 import { FcmTokenUpdateSuccess } from '@app/common-config/response/swagger/domain/user/FcmTokenUpdateSuccess';
 import { PushUpdateSuccess } from '@app/common-config/response/swagger/domain/user/PushUpdateSuccess';
+import { PushUpdateFailV1 } from '@app/common-config/response/swagger/domain/user/PushUpdateFailV1';
 
 @Controller('user')
 @ApiTags('유저 API')
@@ -121,5 +122,42 @@ export class UserApiController {
         '푸시알림 허용 여부 수정에 실패했습니다.',
       );
     }
+  }
+
+  @ApiOperation({
+    summary: '푸시알림 허용 여부 수정 V1',
+    description: `
+    푸시알림 허용 여부 수정 시 deviceId, isPush를 입력받습니다. \n
+    푸시알림 허용 여부 수정 시 입력값을 누락한 경우 400 에러를 출력합니다. \n
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '푸시알림 허용 여부 수정에 성공했습니다.',
+    type: PushUpdateSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiBadRequestResponse({
+    description: '입력 값을 누락했습니다.',
+    type: BadRequestError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '푸시알림 허용 여부 수정에 실패했습니다.',
+    type: PushUpdateFailV1,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Put('/push/v1')
+  async updatePushV1(
+    @CurrentUser() userDto: JwtPayload,
+    @Body() userUpdatePushDto: UserUpdatePushReq,
+  ): Promise<ResponseEntity<string>> {
+    await this.userApiService.updatePushV1(
+      await userUpdatePushDto.toEntity(userDto.deviceId),
+    );
+    return ResponseEntity.OK_WITH('푸시알림 허용 여부 수정에 성공했습니다.');
   }
 }

--- a/apps/api/src/user/UserApiService.ts
+++ b/apps/api/src/user/UserApiService.ts
@@ -1,5 +1,5 @@
 import { UserApiRepository } from './UserApiRepository';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { User } from '@app/entity/domain/user/User.entity';
 
 @Injectable()
@@ -18,5 +18,16 @@ export class UserApiService {
       updatePushUser.deviceId,
       updatePushUser.isPush,
     );
+  }
+
+  async updatePushV1(updatePushUser: User): Promise<void> {
+    try {
+      await this.userApiRepository.updatePush(
+        updatePushUser.deviceId,
+        updatePushUser.isPush,
+      );
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 }

--- a/apps/api/test/unit/domain/user/UserApiService.spec.ts
+++ b/apps/api/test/unit/domain/user/UserApiService.spec.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common';
 import { UserApiService } from '../../../../src/user/UserApiService';
 import { UserApiRepositoryStub } from '../../stub/user/UserApiRepositoryStub';
 import { User } from '@app/entity/domain/user/User.entity';
@@ -26,8 +27,22 @@ describe('UserApiService', () => {
     const sut = new UserApiService(userApiRepository);
 
     // when
-    const actual = await sut.updatePush(await User.updatePush('test', true));
+    const actual = await sut.updatePushV1(await User.updatePush('test', true));
     // then
     expect(actual).toBeUndefined();
+  });
+
+  it('푸시알림 허용 여부 수정에 실패했습니다.', async () => {
+    // given
+    userApiRepository = new UserApiRepositoryStub();
+
+    const sut = new UserApiService(userApiRepository);
+
+    await expect(async () => {
+      // when
+      await sut.updatePushV1(await User.updatePush('test1', true));
+
+      // then
+    }).rejects.toThrowError(new InternalServerErrorException());
   });
 });

--- a/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
+++ b/apps/api/test/unit/stub/user/UserApiRepositoryStub.ts
@@ -16,6 +16,10 @@ export class UserApiRepositoryStub extends UserApiRepository {
   }
 
   override async updatePush(deviceId: string, isPush: boolean) {
+    if (deviceId === 'test1') {
+      throw Error;
+    }
+
     await UpdateResult.Result();
     return;
   }

--- a/libs/common-config/src/response/swagger/domain/user/PushUpdateFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/user/PushUpdateFailV1.ts
@@ -1,0 +1,23 @@
+import { InternalServerError } from '../../common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class PushUpdateFailV1 extends PickType(InternalServerError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '푸시알림 허용 여부 수정에 실패했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: 'Error 메시지',
+    example: 'Internal Server Error',
+    description: '푸시알림 허용 여부 수정에 실패했습니다.',
+  })
+  data: string;
+}


### PR DESCRIPTION
## 작업사항
- 푸시허용 여부 변경 API 에러를 핸들링하는 로직을 추가한 API를 새롭게 생성
- 단위 테스트 실패 경우 추가

## 관계된 이슈, PR 
#146 