### PR TITLE
[test]: 로그인 API 변경으로 인한 단위테스트 경우의 수 추가

### DIFF
--- a/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
+++ b/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
@@ -104,7 +104,7 @@ describe('AuthApiService', () => {
       jwtService,
     );
     // when
-    const actual = await sut.signin(await User.signin('test'));
+    const actual = await sut.signinV1(await User.signin('test'));
     // then
     expect(Object.keys(actual)).toContain('accessToken');
   });
@@ -118,20 +118,50 @@ describe('AuthApiService', () => {
       { secret: 'test', signOptions: { expiresIn: '1y' } },
       new Logger('JwtService', {}),
     );
+    logger = new Logger();
+
     const sut = new AuthApiService(
       userRepository,
       userApiRepository,
       userApiQueryRepository,
       jwtService,
+      logger,
     );
 
     await expect(async () => {
       // when
-      await sut.signin(await User.signinTest());
+      await sut.signinV1(await User.signinTest());
 
       // then
     }).rejects.toThrowError(
       new NotFoundException('입력된 deviceId가 존재하지 않습니다.'),
     );
+  });
+
+  it('이유 모를 문제 때문에 로그인에 실패합니다.', async () => {
+    // given
+    userRepository = new UserRepositoryStub();
+    userApiRepository = new UserApiRepositoryStub();
+    userApiQueryRepository = new UserApiQueryRepositoryStub();
+    jwtService = new JwtServiceStub(
+      { secret: 'test', signOptions: { expiresIn: '1y' } },
+      new Logger('JwtService', {}),
+    );
+    logger = new Logger();
+
+    const sut = new AuthApiService(
+      userRepository,
+      userApiRepository,
+      userApiQueryRepository,
+      jwtService,
+      logger,
+    );
+
+    await expect(async () => {
+      // when
+      await sut.signinV1(await User.signin('test1'));
+
+      // then
+    }).rejects.toThrowError(new InternalServerErrorException());
   });
 });

--- a/apps/api/test/unit/stub/user/UserApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/user/UserApiQueryRepositoryStub.ts
@@ -8,6 +8,10 @@ export class UserApiQueryRepositoryStub extends UserApiQueryRepository {
   }
 
   override async findUserIdByDeviceId(deviceId): Promise<UserId> {
+    if (deviceId === 'test1') {
+      throw Error;
+    }
+
     if (!deviceId) return;
     const row = await User.createId(deviceId);
     return new UserId(row.id);


### PR DESCRIPTION


## 작업사항
1. DB에 없는 deviceId로 로그인을 하는 경우와 이유 모를 문제 때문에 로그인에 실패하는 경우에 대한 단위테스트 추가

## 관계된 이슈, PR 
#3 #2 