### PR TITLE
[fix]: 소환사 즐겨찾기 추가 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -39,6 +39,8 @@ import { FavoriteSummonerDeleteNotFound } from '@app/common-config/response/swag
 import { FavoriteSummonerRes } from './dto/FavoriteSummonerRes.dto';
 import { FavoriteSummonerReadFail } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFail';
 import { FavoriteSummonerReadSuccess } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadSuccess';
+import { FavoriteSummonerCreateLimitFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateLimitFailV1';
+import { FavoriteSummonerCreateFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateFailV1';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -99,6 +101,49 @@ export class FavoriteSummonerApiController {
       }
       return ResponseEntity.ERROR_WITH('소환사 즐겨찾기 추가에 실패했습니다.');
     }
+  }
+
+  @ApiOperation({
+    summary: '소환사 즐겨찾기 추가 V1',
+    description: `
+    소환사 즐겨찾기 추가 시 name, tier, win, lose, profileIconId, puuid, summonerId, leaguePoint, rank를 입력받습니다. \n
+    소환사 즐겨찾기 추가 시 입력값을 누락한 경우 400 에러를 출력합니다. \n
+    소환사 즐겨찾기 추가 시 즐겨찾기 한도가 초과된 경우 403 에러를 출력합니다. \n
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '소환사 즐겨찾기 추가에 성공했습니다.',
+    type: FavoriteSummonerCreateSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiBadRequestResponse({
+    description: '입력 값을 누락했습니다.',
+    type: BadRequestError,
+  })
+  @ApiForbiddenResponse({
+    description: '즐겨찾기 한도가 초과되었습니다.',
+    type: FavoriteSummonerCreateLimitFailV1,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '소환사 즐겨찾기 추가에 실패했습니다.',
+    type: FavoriteSummonerCreateFailV1,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Post('/v1')
+  async createFollowV1(
+    @CurrentUser() userDto: UserReq,
+    @Body() favoriteSummonerDto: FavoriteSummonerReq,
+  ): Promise<ResponseEntity<string>> {
+    await this.favoriteSummonerApiService.createFavoriteSummonerV1(
+      userDto,
+      favoriteSummonerDto,
+    );
+    return ResponseEntity.CREATED_WITH('소환사 즐겨찾기 추가에 성공했습니다.');
   }
 
   @ApiOperation({

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
@@ -15,6 +15,10 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
   }
 
   override async countId(userId: number): Promise<number> {
+    if (userId === 3) {
+      throw Error;
+    }
+
     return userId === 1
       ? this.favoriteSummonerNonLimitCount
       : this.favoriteSummonerLimitCount;

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateFailV1.ts
@@ -1,0 +1,24 @@
+import { InternalServerError } from '@app/common-config/response/swagger/common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerCreateFailV1 extends PickType(
+  InternalServerError,
+  ['statusCode'] as const,
+) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: 'Internal Server Error',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: 'Internal Server Error',
+  })
+  data: string;
+}

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateLimitFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateLimitFailV1.ts
@@ -1,0 +1,24 @@
+import { ForbiddenError } from '@app/common-config/response/swagger/common/error/ForbiddenError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerCreateLimitFailV1 extends PickType(
+  ForbiddenError,
+  ['statusCode'] as const,
+) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Forbidden',
+    description: 'Forbidden',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: '즐겨찾기 한도가 초과되었습니다.',
+    description: '즐겨찾기 한도가 초과되었습니다.',
+  })
+  data: string;
+}


### PR DESCRIPTION


## 작업사항
1. 소환사 즐겨찾기 추가 API 에러 핸들링 로직 추가
2. 단위 테스트 실패 경우 추가

## 관계된 이슈, PR 
#146 