### PR TITLE
[fix]: 소환사 즐겨찾기 삭제 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -41,6 +41,8 @@ import { FavoriteSummonerReadFail } from '@app/common-config/response/swagger/do
 import { FavoriteSummonerReadSuccess } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadSuccess';
 import { FavoriteSummonerCreateLimitFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateLimitFailV1';
 import { FavoriteSummonerCreateFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateFailV1';
+import { FavoriteSummonerDeleteNotFoundV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFoundV1';
+import { FavoriteSummonerDeleteFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFailV1';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -200,6 +202,51 @@ export class FavoriteSummonerApiController {
       }
       return ResponseEntity.ERROR_WITH('소환사 즐겨찾기 취소에 실패했습니다.');
     }
+  }
+
+  @ApiOperation({
+    summary: '소환사 즐겨찾기 취소 V1',
+    description: `
+    소환사 즐겨찾기 취소 시 summonerId를 입력받습니다. \n
+    소환사 즐겨찾기 취소 시 입력값을 누락한 경우 400 에러를 출력합니다. \n
+    소환사 즐겨찾기 취소 시 즐겨찾기 한도가 초과된 경우 403 에러를 출력합니다. \n
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    소환사 즐겨찾기 취소 시 삭제할 즐겨찾기를 조회할 수 없다면 404 에러를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '소환사 즐겨찾기 취소에 성공했습니다.',
+    type: FavoriteSummonerDeleteSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiBadRequestResponse({
+    description: '입력 값을 누락했습니다.',
+    type: BadRequestError,
+  })
+  @ApiNotFoundResponse({
+    description:
+      '소환사 즐겨찾기 취소 시 삭제할 즐겨찾기를 조회할 수 없습니다.',
+    type: FavoriteSummonerDeleteNotFoundV1,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '소환사 즐겨찾기 취소에 실패했습니다.',
+    type: FavoriteSummonerDeleteFailV1,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Delete('/v1')
+  async deleteFollowV1(
+    @CurrentUser() userDto: UserReq,
+    @Body() favoriteSummonerIdDto: FavoriteSummonerIdReq,
+  ): Promise<ResponseEntity<string>> {
+    await this.favoriteSummonerApiService.deleteFavoriteSummonerV1(
+      userDto,
+      favoriteSummonerIdDto,
+    );
+    return ResponseEntity.OK_WITH('소환사 즐겨찾기 취소에 성공했습니다.');
   }
 
   @ApiOperation({

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
@@ -85,6 +85,28 @@ export class FavoriteSummonerApiService {
     await this.deleteNoUseSummonerRecord(favoriteSummonerIdDto);
   }
 
+  async deleteFavoriteSummonerV1(
+    userDto: UserReq,
+    favoriteSummonerIdDto: FavoriteSummonerIdReq,
+  ): Promise<void> {
+    try {
+      await this.checkNotFoundFavoriteSummoner(userDto, favoriteSummonerIdDto);
+      await this.softDeleteFavoriteSummoner(userDto, favoriteSummonerIdDto);
+      await this.deleteNoUseSummonerRecord(favoriteSummonerIdDto);
+    } catch (error) {
+      this.logger.error(
+        `userDto = ${JSON.stringify(
+          userDto,
+        )}, favoriteSummonerIdDto = ${JSON.stringify(favoriteSummonerIdDto)}`,
+        error,
+      );
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException('삭제할 즐겨찾기를 조회할 수 없습니다.');
+      }
+      throw new InternalServerErrorException();
+    }
+  }
+
   async getFavoriteSummoner(userDto: User): Promise<FavoriteSummonerRes[]> {
     return await this.findAllFavoriteSummoners(userDto.id);
   }

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -158,7 +158,7 @@ describe('FavoriteSummonerApiService', () => {
       redisClient,
     );
     // when
-    const actual = await sut.deleteFavoriteSummoner(
+    const actual = await sut.deleteFavoriteSummonerV1(
       UserReq.of('test', 1),
       FavoriteSummonerReq.of(
         'test',
@@ -184,17 +184,21 @@ describe('FavoriteSummonerApiService', () => {
       new SummonerRecordApiQueryRepositoryStub();
     favoriteSummonerApiQueryRepository =
       new FavoriteSummonerApiQueryRepositoryStub();
+    redisClient = new RedisServiceStub();
+    logger = new Logger();
 
     const sut = new FavoriteSummonerApiService(
       favoriteSummonerRepository,
       summonerRecordRepository,
       summonerRecordApiQueryRepository,
       favoriteSummonerApiQueryRepository,
+      redisClient,
+      logger,
     );
 
     await expect(async () => {
       // when
-      await sut.deleteFavoriteSummoner(
+      await sut.deleteFavoriteSummonerV1(
         UserReq.of('test2', 2),
         FavoriteSummonerReq.of(
           'test',
@@ -212,6 +216,46 @@ describe('FavoriteSummonerApiService', () => {
     }).rejects.toThrowError(
       new NotFoundException('삭제할 즐겨찾기를 조회할 수 없습니다.'),
     );
+  });
+
+  it('원인 모를 문제 때문에 즐겨찾기 삭제에 실패했습니다.', async () => {
+    // given
+    favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
+    summonerRecordRepository = new SummonerRecordRepositoryStub();
+    summonerRecordApiQueryRepository =
+      new SummonerRecordApiQueryRepositoryStub();
+    favoriteSummonerApiQueryRepository =
+      new FavoriteSummonerApiQueryRepositoryStub();
+    redisClient = new RedisServiceStub();
+    logger = new Logger();
+
+    const sut = new FavoriteSummonerApiService(
+      favoriteSummonerRepository,
+      summonerRecordRepository,
+      summonerRecordApiQueryRepository,
+      favoriteSummonerApiQueryRepository,
+      redisClient,
+      logger,
+    );
+
+    await expect(async () => {
+      // when
+      await sut.deleteFavoriteSummonerV1(
+        UserReq.of('test2', 3),
+        FavoriteSummonerReq.of(
+          'test',
+          'test',
+          1,
+          1,
+          6,
+          'test',
+          'test',
+          1,
+          'test',
+        ),
+      );
+      // then
+    }).rejects.toThrowError(new InternalServerErrorException());
   });
 
   it('즐겨찾기 조회에 성공했습니다.', async () => {

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
@@ -7,6 +7,7 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
   private readonly favoriteSummonerLimitCount: number = 5;
   private readonly favoriteSummonerNonLimitCount: number = 1;
   private readonly notFindFavoriteSummonerId: number = 2;
+  private readonly throwErrorFavoriteSummonerId: number = 3;
   private readonly nonUsedSummonerIdCount: number = 0;
   private readonly usedSummonerIdCount: number = 1;
 
@@ -42,6 +43,9 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
     userId: number,
     summonerId: string,
   ): Promise<FavoriteSummonerId> {
+    if (userId === this.throwErrorFavoriteSummonerId) {
+      throw Error;
+    }
     if (userId === this.notFindFavoriteSummonerId) return;
     const dto = FavoriteSummonerId.from(1);
     return dto;

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFailV1.ts
@@ -1,0 +1,24 @@
+import { InternalServerError } from '@app/common-config/response/swagger/common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerDeleteFailV1 extends PickType(
+  InternalServerError,
+  ['statusCode'] as const,
+) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: '소환사 즐겨찾기 취소에 실패했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: '소환사 즐겨찾기 취소에 실패했습니다.',
+  })
+  data: string;
+}

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFoundV1.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFoundV1.ts
@@ -1,0 +1,25 @@
+import { NotFoundError } from '@app/common-config/response/swagger/common/error/NotFoundError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerDeleteNotFoundV1 extends PickType(NotFoundError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Not Found',
+    description:
+      '소환사 즐겨찾기 취소 시 삭제할 즐겨찾기를 조회할 수 없습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: '삭제할 즐겨찾기를 조회할 수 없습니다.',
+    description:
+      '소환사 즐겨찾기 취소 시 삭제할 즐겨찾기를 조회할 수 없습니다.',
+  })
+  data: string;
+}


### PR DESCRIPTION


## 작업사항
1. 소환사 즐겨찾기 삭제 API 에러 핸들링 로직 추가
2. 단위 테스트 실패 경우 추가

## 관계된 이슈, PR 
#146 