### PR TITLE
[fix]: 소환사 즐겨찾기 조회 API 에러 로직 처리 변경된 API 추가

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -43,6 +43,7 @@ import { FavoriteSummonerCreateLimitFailV1 } from '@app/common-config/response/s
 import { FavoriteSummonerCreateFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerCreateFailV1';
 import { FavoriteSummonerDeleteNotFoundV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFoundV1';
 import { FavoriteSummonerDeleteFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFailV1';
+import { FavoriteSummonerReadFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFailV1';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -289,5 +290,42 @@ export class FavoriteSummonerApiController {
       this.logger.error(`dto = ${JSON.stringify(userDto)}`, error);
       return ResponseEntity.ERROR_WITH('소환사 즐겨찾기 조회에 실패했습니다.');
     }
+  }
+
+  @ApiOperation({
+    summary: '소환사 즐겨찾기 조회 V1',
+    description: `
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    소환사 즐겨찾기 조회 시 조회를 실패하면 500 에러를 출력합니다. \n
+    소환사 즐겨찾기 조회 시 조회를 성공하면 200 코드를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '소환사 즐겨찾기 조회에 성공했습니다.',
+    type: FavoriteSummonerReadSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '소환사 즐겨찾기 조회에 실패했습니다.',
+    type: FavoriteSummonerReadFailV1,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Get('/v1')
+  async getFollowV1(
+    @CurrentUser() userDto: UserReq,
+  ): Promise<ResponseEntity<FavoriteSummonerRes[] | string>> {
+    const data: FavoriteSummonerRes[] =
+      await this.favoriteSummonerApiService.getFavoriteSummonerV1(
+        await userDto.toEntity(),
+      );
+
+    return ResponseEntity.OK_WITH_DATA(
+      '소환사 즐겨찾기 조회에 성공했습니다.',
+      data,
+    );
   }
 }

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
@@ -111,6 +111,15 @@ export class FavoriteSummonerApiService {
     return await this.findAllFavoriteSummoners(userDto.id);
   }
 
+  async getFavoriteSummonerV1(userDto: User): Promise<FavoriteSummonerRes[]> {
+    try {
+      return await this.findAllFavoriteSummoners(userDto.id);
+    } catch (error) {
+      this.logger.error(`userDto = ${JSON.stringify(userDto)}`, error);
+      throw new InternalServerErrorException();
+    }
+  }
+
   private async checkNotFoundFavoriteSummoner(
     userDto: UserReq,
     favoriteSummonerIdDto: FavoriteSummonerIdReq,

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -274,7 +274,7 @@ describe('FavoriteSummonerApiService', () => {
       favoriteSummonerApiQueryRepository,
     );
     // when
-    const actual = await sut.getFavoriteSummoner(
+    const actual = await sut.getFavoriteSummonerV1(
       await User.jwtUserReq('test', 1),
     );
     // then
@@ -288,5 +288,32 @@ describe('FavoriteSummonerApiService', () => {
     expect(actual[0].profileIconId).toBe(1);
     expect(actual[0].summonerId).toBe('test');
     expect(actual[0].leaguePoint).toBe(1);
+  });
+
+  it('원인 모를 문제 때문에 즐겨찾기 조회에 실패했습니다.', async () => {
+    // given
+    favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
+    summonerRecordRepository = new SummonerRecordRepositoryStub();
+    summonerRecordApiQueryRepository =
+      new SummonerRecordApiQueryRepositoryStub();
+    favoriteSummonerApiQueryRepository =
+      new FavoriteSummonerApiQueryRepositoryStub();
+    redisClient = new RedisServiceStub();
+    logger = new Logger();
+
+    const sut = new FavoriteSummonerApiService(
+      favoriteSummonerRepository,
+      summonerRecordRepository,
+      summonerRecordApiQueryRepository,
+      favoriteSummonerApiQueryRepository,
+      redisClient,
+      logger,
+    );
+
+    await expect(async () => {
+      // when
+      await sut.getFavoriteSummonerV1(await User.jwtUserReq('test', 3));
+      // then
+    }).rejects.toThrowError(new InternalServerErrorException());
   });
 });

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
@@ -54,6 +54,9 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
   override async findAllFavoriteSummoners(
     userId: number,
   ): Promise<FavoriteSummonerRes[]> {
+    if (userId === this.throwErrorFavoriteSummonerId) {
+      throw Error;
+    }
     const dto = [];
     dto.push(
       FavoriteSummonerJoinSummonerRecord.of(

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFailV1.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFailV1.ts
@@ -1,0 +1,23 @@
+import { InternalServerError } from '@app/common-config/response/swagger/common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerReadFailV1 extends PickType(InternalServerError, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: '소환사 즐겨찾기 조회에 실패했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: 'Internal Server Error',
+    description: '소환사 즐겨찾기 조회에 실패했습니다.',
+  })
+  data: string;
+}


### PR DESCRIPTION


## 작업사항
1. 소환사 즐겨찾기 조회 API 에러 핸들링 로직 추가
2. 단위 테스트 실패 경우 추가

## 관계된 이슈, PR 
#146 