### PR TITLE
[refac]: 테스트 서버 소환사 즐겨찾기 API transaction 설정 통합

### DIFF
--- a/apps/api/test/testUtils.ts
+++ b/apps/api/test/testUtils.ts
@@ -34,6 +34,32 @@ export class TestUtils {
     return res.body.data['accessToken'];
   }
 
+  async getAnotherUserToken(): Promise<string> {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ApiTestAppModule],
+    }).compile();
+
+    const app = module.createNestApplication();
+    SetNestApp(app);
+    await app.init();
+
+    const deviceId = 'test1';
+    const firebaseToken = 'test1';
+
+    await request(app.getHttpServer()).post('/auth/signup/v1').send({
+      deviceId,
+      firebaseToken,
+    });
+
+    const res = await request(app.getHttpServer())
+      .post('/auth/signin/v1')
+      .send({
+        deviceId,
+      });
+
+    return res.body.data['accessToken'];
+  }
+
   async createUser(): Promise<number> {
     const module: TestingModule = await Test.createTestingModule({
       imports: [ApiTestAppModule],

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -14,6 +14,7 @@ import {
 import { User } from '@app/entity/domain/user/User.entity';
 import { Logger } from '../../../../../../libs/common-config/test/stub/LoggerStub';
 import { IEventStoreService } from '../../../../../../libs/cache/interface/integration';
+import { ConnectionStub } from '../../../../../../libs/entity/test/stub/ConnectionStub';
 
 describe('FavoriteSummonerApiService', () => {
   let favoriteSummonerRepository;
@@ -22,6 +23,7 @@ describe('FavoriteSummonerApiService', () => {
   let favoriteSummonerApiQueryRepository: FavoriteSummonerApiQueryRepositoryStub;
   let redisClient: IEventStoreService;
   let logger;
+  let connection;
 
   it('즐겨찾기 추가에 성공했습니다.', async () => {
     // given
@@ -33,6 +35,7 @@ describe('FavoriteSummonerApiService', () => {
       new FavoriteSummonerApiQueryRepositoryStub();
     redisClient = new RedisServiceStub();
     logger = new Logger();
+    connection = new ConnectionStub();
 
     const sut = new FavoriteSummonerApiService(
       favoriteSummonerRepository,
@@ -40,6 +43,8 @@ describe('FavoriteSummonerApiService', () => {
       summonerRecordApiQueryRepository,
       favoriteSummonerApiQueryRepository,
       redisClient,
+      logger,
+      connection,
     );
     // when
     const actual = await sut.createFavoriteSummonerV1(

--- a/libs/entity/test/stub/ConnectionStub.ts
+++ b/libs/entity/test/stub/ConnectionStub.ts
@@ -1,0 +1,7 @@
+import { QueryRunnerStub } from './QueryRunnerStub';
+
+export class ConnectionStub {
+  createQueryRunner() {
+    return new QueryRunnerStub();
+  }
+}

--- a/libs/entity/test/stub/ManagerStub.ts
+++ b/libs/entity/test/stub/ManagerStub.ts
@@ -1,0 +1,23 @@
+import { FavoriteSummoner } from '@app/entity/domain/favoriteSummoner/FavoriteSummoner.entity';
+
+export class ManagerStub {
+  private static database = new Map<number, FavoriteSummoner>();
+  private _favoriteSummoner: FavoriteSummoner;
+
+  constructor() {
+    ManagerStub.database.set(1, new FavoriteSummoner());
+  }
+  restore(targetOrEntity, criteria) {
+    return;
+  }
+
+  save(favoriteSummoner: FavoriteSummoner): FavoriteSummoner | object {
+    ManagerStub.database.set(favoriteSummoner.id, favoriteSummoner);
+    if (!this._favoriteSummoner) {
+      this._favoriteSummoner = favoriteSummoner;
+      return this._favoriteSummoner;
+    } else {
+      return { severity: 'ERROR', code: '23505' };
+    }
+  }
+}

--- a/libs/entity/test/stub/QueryRunnerStub.ts
+++ b/libs/entity/test/stub/QueryRunnerStub.ts
@@ -1,0 +1,30 @@
+import { ManagerStub } from './ManagerStub';
+import { UpdateResult } from './UpdateResultStub';
+
+export class QueryRunnerStub {
+  private manager = new ManagerStub();
+
+  softDelete() {
+    return UpdateResult.Result();
+  }
+
+  connect() {
+    return;
+  }
+
+  startTransaction() {
+    return;
+  }
+
+  commitTransaction() {
+    return;
+  }
+
+  rollbackTransaction() {
+    return;
+  }
+
+  release() {
+    return;
+  }
+}


### PR DESCRIPTION
## 작업사항
- 소환사 즐겨찾기 API에 transaction을 적용하여 데이터 무결성을 지키려함.
- 중복되는 조회 쿼리를 제거하고, Promise.all을 활용하여 조회 쿼리를 병렬 처리함.
- 트랜잭션을 활용하여 데이터 저장 쿼리가 하나라도 실패하면, 전부 실패하도록 설정함. 모두 성공해야 commit 되게끔 설정.
- TypeORM의 Connection은 기본적으로 Connection Pool을 만들어서 사용하는데, 단일 데이터베이스 커넥션을 따로 만들어서 세부적으로 관리하기 위해 QueryRunner를 활용함.
- QueryRunner 인스턴스를 connect 함수를 통해 데이터베이스에 연결한 뒤 쿼리를 날리거나 트랜잭션을 수행할 수 있음. 
- queryRunner를 다 사용하고 나면 release를 통해 인스턴스를 해제해 줘야함.

## 관계된 이슈, PR 
#161 