### PR TITLE
[feat]: 소환사 전적 갱신 조회 API 도입

### DIFF
--- a/apps/api/src/changedTier/ChangedTierApiModule.ts
+++ b/apps/api/src/changedTier/ChangedTierApiModule.ts
@@ -1,0 +1,15 @@
+import { ChangedTierApiQueryRepository } from './ChangedTierApiQueryRepository';
+import { Module } from '@nestjs/common';
+import { WinstonModule } from 'nest-winston';
+import { getWinstonLogger } from '@app/common-config/getWinstonLogger';
+import { ChangedTierModule } from '@app/entity/domain/changedTier/ChangedTierModule';
+
+@Module({
+  imports: [
+    ChangedTierModule,
+    WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'api')),
+  ],
+  providers: [ChangedTierApiQueryRepository],
+  exports: [ChangedTierApiQueryRepository],
+})
+export class ChangedTierApiModule {}

--- a/apps/api/src/changedTier/ChangedTierApiQueryRepository.ts
+++ b/apps/api/src/changedTier/ChangedTierApiQueryRepository.ts
@@ -1,0 +1,40 @@
+import { ChangedTierPagination } from './../../../../libs/entity/src/domain/changedTier/ChangedTierPagination';
+import { plainToInstance } from 'class-transformer';
+import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
+import { ChangedTier } from '@app/entity/domain/changedTier/ChangedTier.entity';
+
+@EntityRepository(ChangedTier)
+export class ChangedTierApiQueryRepository extends Repository<ChangedTier> {
+  async findChangedTierByPagination(
+    summonerId: string,
+    offset: number,
+    limit: number,
+  ): Promise<ChangedTierPagination[]> {
+    const changedTierArray: ChangedTierPagination[] = [];
+    const rows: ChangedTier[] = await this.findAllChangedTier(
+      summonerId,
+      offset,
+      limit,
+    );
+    rows.map(row =>
+      changedTierArray.push(plainToInstance(ChangedTierPagination, row)),
+    );
+    return changedTierArray;
+  }
+
+  private async findAllChangedTier(
+    summonerId: string,
+    offset: number,
+    limit: number,
+  ) {
+    const queryBuilder = createQueryBuilder()
+      .select(['id', 'match_id', 'tier', 'rank', 'summoner_id', 'status'])
+      .from(ChangedTier, 'changedTier')
+      .where(`changedTier.summoner_id =:summonerId`, { summonerId })
+      .orderBy('changedTier.created_at', 'DESC')
+      .limit(limit)
+      .offset(offset);
+
+    return await queryBuilder.getRawMany();
+  }
+}

--- a/apps/api/src/changedTier/interface/IChangedTierReadSuccess.ts
+++ b/apps/api/src/changedTier/interface/IChangedTierReadSuccess.ts
@@ -1,0 +1,12 @@
+type FavoriteSummonerChangedTierReadSuccessData = {
+  id: string;
+  match_id: string;
+  tier: string;
+  rank: string;
+  summoner_id: string;
+  status: string;
+};
+
+export interface IFavoriteSummonerChangedTierReadSuccess {
+  summonerId: FavoriteSummonerChangedTierReadSuccessData[];
+}

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -9,6 +9,7 @@ import {
   Get,
   Inject,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { Logger } from 'winston';
@@ -21,6 +22,7 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
@@ -44,6 +46,10 @@ import { FavoriteSummonerCreateFailV1 } from '@app/common-config/response/swagge
 import { FavoriteSummonerDeleteNotFoundV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFoundV1';
 import { FavoriteSummonerDeleteFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFailV1';
 import { FavoriteSummonerReadFailV1 } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFailV1';
+import { FavoriteSummonerChangedTierReq } from './dto/FavoriteSummonerChangedTierReq.dto';
+import { FavoriteSummonerChangedTierQuery } from './dto/FavoriteSummonerChangedTierQuery.dto';
+import { FavoriteSummonerChangedTierRes } from './dto/FavoriteSummonerChangedTierRes.dto';
+import { FavoriteSummonerChangedTierReadSuccess } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerChangedTierReadSuccess';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -325,6 +331,56 @@ export class FavoriteSummonerApiController {
 
     return ResponseEntity.OK_WITH_DATA(
       '소환사 즐겨찾기 조회에 성공했습니다.',
+      data,
+    );
+  }
+
+  @ApiOperation({
+    summary: '소환사 전적 갱신 조회',
+    description: `
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    소환사 전적 갱신 조회 시 조회를 실패하면 500 에러를 출력합니다. \n
+    소환사 전적 갱신 조회 시 조회를 성공하면 200 코드를 출력합니다. \n
+    `,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: true,
+    description: '최대 몇 개의 contents를 가져올 것인지에 대한 값입니다.',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: true,
+    description:
+      'contents의 시작페이지의 수를 나타냅니다. 0을 제외한 양수의 값입니다.',
+  })
+  @ApiOkResponse({
+    description: '소환사 전적 갱신 조회에 성공했습니다.',
+    type: FavoriteSummonerChangedTierReadSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '소환사 전적 갱신 조회에 실패했습니다.',
+    type: FavoriteSummonerReadFailV1,
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JwtAuthGuard)
+  @Post('/changedTier')
+  async changedTier(
+    @Query() queryDto: FavoriteSummonerChangedTierQuery,
+    @Body() favoriteSummonerChangedTierDto: FavoriteSummonerChangedTierReq,
+  ): Promise<ResponseEntity<FavoriteSummonerChangedTierRes[] | string>> {
+    const data: FavoriteSummonerChangedTierRes[] =
+      await this.favoriteSummonerApiService.getChangedTier(
+        queryDto,
+        favoriteSummonerChangedTierDto,
+      );
+
+    return ResponseEntity.OK_WITH_DATA(
+      '소환사 전적 갱신 조회에 성공했습니다.',
       data,
     );
   }

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiModule.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiModule.ts
@@ -9,6 +9,7 @@ import { FavoriteSummonerModule } from '@app/entity/domain/favoriteSummoner/Favo
 import { SummonerRecordApiModule } from '../summonerRecord/SummonerRecordApiModule';
 import { SummonerRecordModule } from '@app/entity/domain/summonerRecord/SummonerRecordModule';
 import { FavoriteSummonerApiQueryRepository } from './FavoriteSummonerApiQueryRepository';
+import { ChangedTierApiModule } from '../changedTier/ChangedTierApiModule';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { FavoriteSummonerApiQueryRepository } from './FavoriteSummonerApiQueryRe
     SummonerRecordModule,
     WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'api')),
     SummonerRecordApiModule,
+    ChangedTierApiModule,
     EventStoreModule,
   ],
   controllers: [FavoriteSummonerApiController],

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
@@ -26,7 +26,6 @@ import { IEventStoreService } from '../../../../libs/cache/interface/integration
 import { FavoriteSummonerChangedTierReq } from './dto/FavoriteSummonerChangedTierReq.dto';
 import { ChangedTierApiQueryRepository } from '../changedTier/ChangedTierApiQueryRepository';
 import { FavoriteSummonerChangedTierQuery } from './dto/FavoriteSummonerChangedTierQuery.dto';
-import { IFavoriteSummonerChangedTierReadSuccess } from '../changedTier/interface/IChangedTierReadSuccess';
 import { FavoriteSummonerChangedTierRes } from './dto/FavoriteSummonerChangedTierRes.dto';
 
 @Injectable()

--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierQuery.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierQuery.dto.ts
@@ -1,0 +1,7 @@
+import { PageRequest } from '@app/common-config/abstract/page.request';
+
+export class FavoriteSummonerChangedTierQuery extends PageRequest {
+  constructor() {
+    super();
+  }
+}

--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierReq.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierReq.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsArray, IsNotEmpty } from 'class-validator';
+
+export class FavoriteSummonerChangedTierReq {
+  @ApiProperty({
+    example: [
+      'GDjFzPPZ3PiiAmPCblXDLv2yRh430fyVjWlpC8zAXaDp9o12bpOZCzfnsw',
+      '8_MjoUjTvMvLLAHQj1PgSCV46Ux1hkGxOy2adI_s2OepAuremBy9ACAmKQ',
+      'a_BJjxFEWpHDgppS0TAxf_PndfQBTHGwFW1mTnkG8L6t8fw',
+      'AQuPJ-BiLJYNZta4y5c3Qf_HZ1qyTSyjiHv0IZzZAjL16E6L6q17gHH2Dg',
+    ],
+    description: '소환사 전적 갱신 조회 API를 위해 입력 받는 summonerId입니다.',
+    required: true,
+  })
+  @Expose()
+  @IsNotEmpty()
+  @IsArray()
+  summonerId: string[];
+}

--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierRes.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierRes.dto.ts
@@ -1,0 +1,73 @@
+import { Exclude, Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { ChangedTierPagination } from '@app/entity/domain/changedTier/ChangedTierPagination';
+import { IFavoriteSummonerChangedTierReadSuccess } from '../../changedTier/interface/IChangedTierReadSuccess';
+
+export class FavoriteSummonerChangedTierRes
+  implements IFavoriteSummonerChangedTierReadSuccess
+{
+  @Exclude() private readonly _id: number;
+  @Exclude() private readonly _matchId: string;
+  @Exclude() private readonly _tier: string;
+  @Exclude() private readonly _rank: string;
+  @Exclude() private readonly _summonerId: string;
+  @Exclude() private readonly _status: string;
+
+  constructor(changedTier: ChangedTierPagination) {
+    this._id = changedTier.id;
+    this._matchId = changedTier.matchId;
+    this._tier = changedTier.tier;
+    this._rank = changedTier.rank;
+    this._summonerId = changedTier.summonerId;
+    this._status = changedTier.status;
+  }
+
+  @ApiProperty()
+  @Expose()
+  summonerId: [
+    {
+      id: string;
+      match_id: string;
+      tier: string;
+      rank: string;
+      summoner_id: string;
+      status: string;
+    },
+  ];
+
+  @ApiProperty()
+  @Expose()
+  get id(): number {
+    return this._id;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get match_id(): string {
+    return this._matchId;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get tier(): string {
+    return this._tier;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get rank(): string {
+    return this._rank;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get summoner_id(): string {
+    return this._summonerId;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get status(): string {
+    return this._status;
+  }
+}

--- a/apps/api/test/FavoriteSummonerApiTestModule.ts
+++ b/apps/api/test/FavoriteSummonerApiTestModule.ts
@@ -9,6 +9,7 @@ import { FavoriteSummonerApiController } from '../src/favoriteSummoner/FavoriteS
 import { FavoriteSummonerApiService } from '../src/favoriteSummoner/FavoriteSummonerApiService';
 import { FavoriteSummonerApiRepository } from '../src/favoriteSummoner/FavoriteSummonerApiRepository';
 import { FavoriteSummonerApiQueryRepository } from '../src/favoriteSummoner/FavoriteSummonerApiQueryRepository';
+import { ChangedTierApiModule } from '../src/changedTier/ChangedTierApiModule';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { FavoriteSummonerApiQueryRepository } from '../src/favoriteSummoner/Favo
     SummonerRecordModule,
     WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'api')),
     SummonerRecordApiModule,
+    ChangedTierApiModule,
     EventStoreTestModule,
   ],
   controllers: [FavoriteSummonerApiController],

--- a/apps/api/test/e2e/FavoriteSummonerApiController.e2e.spec.ts
+++ b/apps/api/test/e2e/FavoriteSummonerApiController.e2e.spec.ts
@@ -14,12 +14,14 @@ import { FavoriteSummoner } from '@app/entity/domain/favoriteSummoner/FavoriteSu
 import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { EventStoreTestServiceImplement } from '../../../../libs/cache/EventStoreTestService';
 import { EInfrastructureInjectionToken } from '@app/common-config/enum/InfrastructureInjectionToken';
+import { ChangedTier } from '@app/entity/domain/changedTier/ChangedTier.entity';
 
 describe('FavoriteSummonerApiController (e2e)', () => {
   let app: INestApplication;
   let userRepository: Repository<User>;
   let favoriteRepository: Repository<FavoriteSummoner>;
   let summonerRecordRepository: Repository<SummonerRecord>;
+  let changedTierRepository: Repository<ChangedTier>;
   let testUtils: TestUtils;
   let redisClient: EventStoreTestServiceImplement;
   let userToken: string;
@@ -37,6 +39,7 @@ describe('FavoriteSummonerApiController (e2e)', () => {
     redisClient = module.get<EventStoreTestServiceImplement>(
       EInfrastructureInjectionToken.EVENT_STORE.name,
     );
+    changedTierRepository = module.get(getRepositoryToken(ChangedTier));
 
     SetNestApp(app); // ClassSerializerInterceptor 적용
     await app.init();
@@ -45,6 +48,7 @@ describe('FavoriteSummonerApiController (e2e)', () => {
     await summonerRecordRepository.delete({});
     await redisClient.flushall();
     userToken = await testUtils.getDefaultUserToken();
+    await changedTierRepository.delete({});
   });
 
   afterAll(async () => {
@@ -57,6 +61,7 @@ describe('FavoriteSummonerApiController (e2e)', () => {
     await summonerRecordRepository.delete({});
     await redisClient.flushall();
     userToken = await testUtils.getDefaultUserToken();
+    await changedTierRepository.delete({});
   });
 
   it('/favoriteSummoner/v1 (POST)', async () => {

--- a/apps/api/test/integration/domain/favoriteSummoner/FavoriteSummonerApiService.int.spec.ts
+++ b/apps/api/test/integration/domain/favoriteSummoner/FavoriteSummonerApiService.int.spec.ts
@@ -1,3 +1,5 @@
+import { ChangedTierApiQueryRepository } from './../../../../src/changedTier/ChangedTierApiQueryRepository';
+import { ChangedTierApiModule } from './../../../../../push/src/changedTier/ChangedTierApiModule';
 import { UserModule } from './../../../../../../libs/entity/src/domain/user/UserModule';
 import { TestUtils } from './../../../testUtils';
 import { FavoriteSummoner } from '@app/entity/domain/favoriteSummoner/FavoriteSummoner.entity';
@@ -21,6 +23,7 @@ import { EventStoreTestServiceImplement } from '../../../../../../libs/cache/Eve
 import { User } from '@app/entity/domain/user/User.entity';
 import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { FavoriteSummonerIdReq } from '../../../../src/favoriteSummoner/dto/FavoriteSummonerIdReq.dto';
+import { ChangedTier } from '@app/entity/domain/changedTier/ChangedTier.entity';
 
 describe('FavoriteSummonerApiService', () => {
   let favoriteSummonerRepository: Repository<FavoriteSummoner>;
@@ -30,6 +33,7 @@ describe('FavoriteSummonerApiService', () => {
   let sut: FavoriteSummonerApiService;
   let testUtils: TestUtils;
   let userId: number;
+  let changedTierRepository: Repository<ChangedTier>;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -37,6 +41,7 @@ describe('FavoriteSummonerApiService', () => {
         FavoriteSummonerModule,
         SummonerRecordModule,
         SummonerRecordApiModule,
+        ChangedTierApiModule,
         ConfigModule.forRoot({
           isGlobal: true,
           validationSchema: ValidationSchema,
@@ -50,12 +55,14 @@ describe('FavoriteSummonerApiService', () => {
         FavoriteSummonerApiService,
         FavoriteSummonerApiRepository,
         FavoriteSummonerApiQueryRepository,
+        ChangedTierApiQueryRepository,
       ],
     }).compile();
 
     favoriteSummonerRepository = module.get('FavoriteSummonerRepository');
     userRepository = module.get('UserRepository');
     summonerRecordRepository = module.get('SummonerRecordRepository');
+    changedTierRepository = module.get('ChangedTierRepository');
 
     sut = module.get<FavoriteSummonerApiService>(FavoriteSummonerApiService);
     redisClient = module.get<EventStoreTestServiceImplement>(
@@ -67,6 +74,7 @@ describe('FavoriteSummonerApiService', () => {
     await userRepository.delete({});
     await summonerRecordRepository.delete({});
     await redisClient.flushall();
+    await changedTierRepository.delete({});
   });
 
   afterAll(async () => {
@@ -78,6 +86,7 @@ describe('FavoriteSummonerApiService', () => {
     await userRepository.delete({});
     await summonerRecordRepository.delete({});
     await redisClient.flushall();
+    await changedTierRepository.delete({});
   });
 
   it('createFavoriteSummonerV1', async () => {

--- a/apps/push/src/changedTier/ChangedTierApiModule.ts
+++ b/apps/push/src/changedTier/ChangedTierApiModule.ts
@@ -1,0 +1,15 @@
+import { ChangedTierApiQueryRepository } from './ChangedTierApiQueryRepository';
+import { Module } from '@nestjs/common';
+import { WinstonModule } from 'nest-winston';
+import { getWinstonLogger } from '@app/common-config/getWinstonLogger';
+import { ChangedTierModule } from '@app/entity/domain/changedTier/ChangedTierModule';
+
+@Module({
+  imports: [
+    ChangedTierModule,
+    WinstonModule.forRoot(getWinstonLogger(process.env.NODE_ENV, 'push')),
+  ],
+  providers: [ChangedTierApiQueryRepository],
+  exports: [ChangedTierApiQueryRepository],
+})
+export class ChangedTierApiModule {}

--- a/apps/push/src/changedTier/ChangedTierApiQueryRepository.ts
+++ b/apps/push/src/changedTier/ChangedTierApiQueryRepository.ts
@@ -1,0 +1,7 @@
+import { plainToInstance } from 'class-transformer';
+import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
+import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
+import { ChangedTier } from '@app/entity/domain/changedTier/ChangedTier.entity';
+
+@EntityRepository(ChangedTier)
+export class ChangedTierApiQueryRepository extends Repository<SummonerRecord> {}

--- a/apps/push/src/changedTier/ChangedTierApiQueryRepository.ts
+++ b/apps/push/src/changedTier/ChangedTierApiQueryRepository.ts
@@ -1,7 +1,6 @@
 import { plainToInstance } from 'class-transformer';
-import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
 import { ChangedTier } from '@app/entity/domain/changedTier/ChangedTier.entity';
 
 @EntityRepository(ChangedTier)
-export class ChangedTierApiQueryRepository extends Repository<SummonerRecord> {}
+export class ChangedTierApiQueryRepository extends Repository<ChangedTier> {}

--- a/apps/push/src/push/PushApiModule.ts
+++ b/apps/push/src/push/PushApiModule.ts
@@ -20,6 +20,7 @@ import { EventStoreModule } from '../../../../libs/cache/EventStoreModule';
 import { ModuleRef } from '@nestjs/core';
 import { ConfigService } from '../../../../libs/entity/config/configService';
 import { ChangedTierApiModule } from '../changedTier/ChangedTierApiModule';
+import { ChangedTierModule } from '@app/entity/domain/changedTier/ChangedTierModule';
 
 const application: Provider[] = [
   {
@@ -49,6 +50,7 @@ const application: Provider[] = [
     ScheduleModule.forRoot(),
     SummonerRecordApiModule,
     ChangedTierApiModule,
+    ChangedTierModule,
     EventStoreModule,
   ],
   controllers: [PushApiController],

--- a/apps/push/src/push/PushApiModule.ts
+++ b/apps/push/src/push/PushApiModule.ts
@@ -19,6 +19,7 @@ import { EApplicationInjectionToken } from '@app/common-config/enum/ApplicationI
 import { EventStoreModule } from '../../../../libs/cache/EventStoreModule';
 import { ModuleRef } from '@nestjs/core';
 import { ConfigService } from '../../../../libs/entity/config/configService';
+import { ChangedTierApiModule } from '../changedTier/ChangedTierApiModule';
 
 const application: Provider[] = [
   {
@@ -47,6 +48,7 @@ const application: Provider[] = [
     BullModule,
     ScheduleModule.forRoot(),
     SummonerRecordApiModule,
+    ChangedTierApiModule,
     EventStoreModule,
   ],
   controllers: [PushApiController],

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -89,6 +89,8 @@ export class PushApiService {
     tier: string,
     rank: string,
   ): Promise<Bull.Job<any>> {
+    await this.addChangeTierRank(puuid, summonerId, tier, rank, checkWinOrLose);
+
     if (checkWinOrLose === 'win') {
       return await this.addWinPushQueue(summonerId, summonerName);
     }
@@ -96,11 +98,11 @@ export class PushApiService {
       return await this.addLosePushQueue(summonerId, summonerName);
     }
     if (checkWinOrLose === 'tierUp' || checkWinOrLose === 'rankUp') {
-      await this.addChangeTierRank(puuid, summonerId, tier, rank);
+      // await this.addChangeTierRank(puuid, summonerId, tier, rank);
       return await this.addTierUpPushQueue(summonerId, summonerName);
     }
     if (checkWinOrLose === 'tierDown' || checkWinOrLose === 'rankDown') {
-      await this.addChangeTierRank(puuid, summonerId, tier, rank);
+      // await this.addChangeTierRank(puuid, summonerId, tier, rank);
       return await this.addTierDownPushQueue(summonerId, summonerName);
     }
     return;
@@ -123,17 +125,23 @@ export class PushApiService {
     summonerId: string,
     tier: string,
     rank: string,
+    status: string,
   ) {
     try {
       const matchId: string = await this.riotApiJobService.recentMatchIdResult(
         puuid,
       );
 
+      // 테스트를 위한 임시 코드
+      if (status === 'win') status = 'tierUp';
+      if (status === 'lose') status = 'tierDown';
+
       const changedTier = await ChangedTier.createChangedTier(
         summonerId,
         matchId,
         tier,
         rank,
+        status,
       );
 
       await this.changedTierRepository.save(changedTier);

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -115,7 +115,8 @@ export class PushApiService {
     riotApiResponse: PushRiotApi,
     redisResponse: string[],
   ): Promise<boolean> {
-    const [win, lose, tier] = redisResponse;
+    const [win, lose, tier, rank] = redisResponse;
+    if (riotApiResponse[0].rank !== rank) return true;
     if (riotApiResponse[0].tier !== tier) return true;
     if (riotApiResponse[0].win !== Number(win)) return true;
     if (riotApiResponse[0].lose !== Number(lose)) return true;

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -11,6 +11,7 @@ import { SummonerRecordApiQueryRepository } from '../summonerRecord/SummonerReco
 import { BullService } from '../../../../libs/entity/queue/src/lib/BullService';
 
 import { IPushApiTask } from './interface/IPushApiTask';
+import { ChangedTierApiQueryRepository } from '../changedTier/ChangedTierApiQueryRepository';
 
 @Injectable()
 export class PushApiService {
@@ -23,6 +24,7 @@ export class PushApiService {
     private readonly bullService?: BullService,
     @Inject(EApplicationInjectionToken.PUSH_API_TASK.name)
     private readonly tasks?: IPushApiTask,
+    private readonly changedTierApiQueryRepository?: ChangedTierApiQueryRepository,
   ) {}
   @Interval('pushCronTask', 180000)
   async addMessageQueue(): Promise<void> {

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -89,8 +89,6 @@ export class PushApiService {
     tier: string,
     rank: string,
   ): Promise<Bull.Job<any>> {
-    await this.addChangeTierRank(puuid, summonerId, tier, rank, checkWinOrLose);
-
     if (checkWinOrLose === 'win') {
       return await this.addWinPushQueue(summonerId, summonerName);
     }
@@ -98,11 +96,23 @@ export class PushApiService {
       return await this.addLosePushQueue(summonerId, summonerName);
     }
     if (checkWinOrLose === 'tierUp' || checkWinOrLose === 'rankUp') {
-      // await this.addChangeTierRank(puuid, summonerId, tier, rank);
+      await this.addChangeTierRank(
+        puuid,
+        summonerId,
+        tier,
+        rank,
+        checkWinOrLose,
+      );
       return await this.addTierUpPushQueue(summonerId, summonerName);
     }
     if (checkWinOrLose === 'tierDown' || checkWinOrLose === 'rankDown') {
-      // await this.addChangeTierRank(puuid, summonerId, tier, rank);
+      await this.addChangeTierRank(
+        puuid,
+        summonerId,
+        tier,
+        rank,
+        checkWinOrLose,
+      );
       return await this.addTierDownPushQueue(summonerId, summonerName);
     }
     return;
@@ -131,10 +141,6 @@ export class PushApiService {
       const matchId: string = await this.riotApiJobService.recentMatchIdResult(
         puuid,
       );
-
-      // 테스트를 위한 임시 코드
-      if (status === 'win') status = 'tierUp';
-      if (status === 'lose') status = 'tierDown';
 
       const changedTier = await ChangedTier.createChangedTier(
         summonerId,

--- a/apps/push/src/push/PushApiService.ts
+++ b/apps/push/src/push/PushApiService.ts
@@ -82,10 +82,10 @@ export class PushApiService {
     if (checkWinOrLose === 'lose') {
       return await this.addLosePushQueue(summonerId, summonerName);
     }
-    if (checkWinOrLose === 'tierUp') {
+    if (checkWinOrLose === 'tierUp' || checkWinOrLose === 'rankUp') {
       return await this.addTierUpPushQueue(summonerId, summonerName);
     }
-    if (checkWinOrLose === 'tierDown') {
+    if (checkWinOrLose === 'tierDown' || checkWinOrLose === 'rankDown') {
       return await this.addTierDownPushQueue(summonerId, summonerName);
     }
     return;
@@ -95,17 +95,23 @@ export class PushApiService {
     riotApiResponse: PushRiotApi,
     redisResponse: string[],
   ): Promise<string> {
-    const [win, lose, tier] = redisResponse;
+    const [win, lose, tier, rank] = redisResponse;
 
     if (riotApiResponse[0].win !== Number(win)) {
       if (riotApiResponse[0].tier !== tier) {
         return 'tierUp';
+      }
+      if (riotApiResponse[0].rank !== rank) {
+        return 'rankUp';
       }
       return 'win';
     }
     if (riotApiResponse[0].lose !== Number(lose)) {
       if (riotApiResponse[0].tier !== tier) {
         return 'tierDown';
+      }
+      if (riotApiResponse[0].rank !== rank) {
+        return 'rankDown';
       }
       return 'lose';
     }

--- a/apps/push/src/push/dto/PushRiotApi.ts
+++ b/apps/push/src/push/dto/PushRiotApi.ts
@@ -3,7 +3,6 @@ import { Exclude, Expose } from 'class-transformer';
 export class PushRiotApi {
   @Exclude() leagueId: string;
   @Exclude() queueType: string;
-  @Exclude() rank: string;
   @Exclude() summonerId: string;
   @Exclude() leaguePoints: number;
   @Exclude() veteran: boolean;
@@ -19,6 +18,9 @@ export class PushRiotApi {
 
   @Expose({ name: 'tier' })
   tier: string;
+
+  @Expose({ name: 'rank' })
+  rank: string;
 
   @Expose({ name: 'summonerName' })
   summonerName: string;

--- a/apps/push/src/summonerRecord/SummonerRecordApiQueryRepository.ts
+++ b/apps/push/src/summonerRecord/SummonerRecordApiQueryRepository.ts
@@ -2,6 +2,7 @@ import { plainToInstance } from 'class-transformer';
 import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
 import { SummonerRecordSummonerId } from '@app/entity/domain/summonerRecord/SummonerRecordSummonerId';
+import { SummonerRecordPuuid } from '@app/entity/domain/summonerRecord/SummonerRecordPuuid';
 
 @EntityRepository(SummonerRecord)
 export class SummonerRecordApiQueryRepository extends Repository<SummonerRecord> {
@@ -10,11 +11,27 @@ export class SummonerRecordApiQueryRepository extends Repository<SummonerRecord>
     return plainToInstance(SummonerRecordSummonerId, row);
   }
 
+  async findOnePuuidAtSummonerRecord(
+    summonerId: string,
+  ): Promise<SummonerRecordPuuid> {
+    const row = await this.findOnePuuidBySummonerId(summonerId);
+    return plainToInstance(SummonerRecordPuuid, row);
+  }
+
   private async findAllSummonerId() {
     const queryBuilder = createQueryBuilder()
       .select(['summoner_id'])
       .from(SummonerRecord, 'summonerRecord');
 
     return await queryBuilder.getRawMany();
+  }
+
+  private async findOnePuuidBySummonerId(summonerId: string) {
+    const queryBuilder = createQueryBuilder()
+      .select(['puuid'])
+      .from(SummonerRecord, 'summonerRecord')
+      .where(`summonerRecord.summonerId =:summonerId`, { summonerId });
+
+    return await queryBuilder.getRawOne();
   }
 }

--- a/apps/push/test/unit/stub/summonerRecord/SummonerRecordApiQueryRepositoryStub.ts
+++ b/apps/push/test/unit/stub/summonerRecord/SummonerRecordApiQueryRepositoryStub.ts
@@ -1,3 +1,4 @@
+import { SummonerRecordPuuid } from '@app/entity/domain/summonerRecord/SummonerRecordPuuid';
 import { SummonerRecordSummonerId } from '@app/entity/domain/summonerRecord/SummonerRecordSummonerId';
 import { SummonerRecordApiQueryRepository } from '../../../../src/summonerRecord/SummonerRecordApiQueryRepository';
 
@@ -10,5 +11,9 @@ export class SummonerRecordApiQueryRepositoryStub extends SummonerRecordApiQuery
   > {
     const dto = SummonerRecordSummonerId.from('test');
     return [dto];
+  }
+  override async findOnePuuidAtSummonerRecord(): Promise<SummonerRecordPuuid> {
+    const dto = SummonerRecordPuuid.from('test');
+    return dto;
   }
 }

--- a/libs/cache/EventStoreService.ts
+++ b/libs/cache/EventStoreService.ts
@@ -133,6 +133,8 @@ export class EventStoreServiceImplement implements IEventStoreService {
       0,
       `summonerId:${summonerId}:tier`,
       '언랭',
+      `summonerId:${summonerId}:rank`,
+      '언랭',
     );
   }
   async summonerRecordMget(summonerId: string): Promise<string[]> {

--- a/libs/cache/EventStoreService.ts
+++ b/libs/cache/EventStoreService.ts
@@ -95,6 +95,7 @@ export class EventStoreServiceImplement implements IEventStoreService {
       await redisClient.del(`summonerId:${summonerId}:lose`);
       await redisClient.del(`summonerId:${summonerId}:tier`);
       await redisClient.del(`summonerId:${summonerId}:win`);
+      await redisClient.del(`summonerId:${summonerId}:rank`);
       await redisClient.srem('summonerId', 'error');
 
       await redisClient.exec();
@@ -115,6 +116,8 @@ export class EventStoreServiceImplement implements IEventStoreService {
         riotApiResponse[0].lose,
         `summonerId:${summonerId}:tier`,
         riotApiResponse[0].tier,
+        `summonerId:${summonerId}:rank`,
+        riotApiResponse[0].rank,
       );
     } catch (error) {
       console.error(error);

--- a/libs/cache/EventStoreService.ts
+++ b/libs/cache/EventStoreService.ts
@@ -43,7 +43,7 @@ export class EventStoreServiceImplement implements IEventStoreService {
   ): Promise<void> {
     const redisClient = this.master;
 
-    const [win, lose, tier] = await this.summonerRecordMget(
+    const [win, lose, tier, rank] = await this.summonerRecordMget(
       favoriteSummonerDto.summonerId,
     );
 
@@ -63,6 +63,12 @@ export class EventStoreServiceImplement implements IEventStoreService {
       await redisClient.set(
         `summonerId:${favoriteSummonerDto.summonerId}:tier`,
         favoriteSummonerDto.tier,
+      );
+
+    if (!rank)
+      await redisClient.set(
+        `summonerId:${favoriteSummonerDto.summonerId}:rank`,
+        favoriteSummonerDto.rank,
       );
 
     await redisClient.sadd('summonerId', favoriteSummonerDto.summonerId);
@@ -131,6 +137,7 @@ export class EventStoreServiceImplement implements IEventStoreService {
       `summonerId:${summonerId}:win`,
       `summonerId:${summonerId}:lose`,
       `summonerId:${summonerId}:tier`,
+      `summonerId:${summonerId}:rank`,
     );
   }
 

--- a/libs/cache/EventStoreService.ts
+++ b/libs/cache/EventStoreService.ts
@@ -81,6 +81,7 @@ export class EventStoreServiceImplement implements IEventStoreService {
     await redisClient.del(`summonerId:${summonerId}:win`);
     await redisClient.del(`summonerId:${summonerId}:lose`);
     await redisClient.del(`summonerId:${summonerId}:tier`);
+    await redisClient.del(`summonerId:${summonerId}:rank`);
     await redisClient.srem('summonerId', summonerId);
     await redisClient.exec();
   }

--- a/libs/common-config/src/abstract/page.request.ts
+++ b/libs/common-config/src/abstract/page.request.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, IsPositive, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export abstract class PageRequest {
+  @IsNotEmpty()
+  @IsPositive()
+  @Type(() => Number)
+  page: number | 1;
+
+  @IsNotEmpty()
+  @IsPositive()
+  @Max(100)
+  @Type(() => Number)
+  limit: number | 10;
+
+  getOffset(): number {
+    return (this.page - 1) * this.limit;
+  }
+
+  getLimit(): number {
+    return this.limit;
+  }
+
+  getPage(): number {
+    return this.page;
+  }
+}

--- a/libs/common-config/src/job/riot/RiotApiJobService.ts
+++ b/libs/common-config/src/job/riot/RiotApiJobService.ts
@@ -9,11 +9,18 @@ import { PushRiotApi } from '../../../../../apps/push/src/push/dto/PushRiotApi';
 export class RiotApiJobService implements IRiotApiJobService {
   public async soloRankResult(summonerId: string) {
     const riotApiResponse = await this.riotLeagueApi(summonerId);
-    // const riotApiResponse = false;
-
     return riotApiResponse === false
       ? false
       : plainToInstance(PushRiotApi, riotApiResponse);
+  }
+
+  public async recentMatchIdResult(puuid: string): Promise<string> {
+    try {
+      const riotApiResponse = await this.riotMatchIdApi(puuid);
+      return riotApiResponse[0];
+    } catch (error) {
+      throw error;
+    }
   }
 
   private async riotLeagueApi(summonerId: string): Promise<any> {
@@ -24,6 +31,18 @@ export class RiotApiJobService implements IRiotApiJobService {
         riotApiReturn => riotApiReturn['queueType'] === 'RANKED_SOLO_5x5',
       );
       return soloRankResult.length === 0 ? false : soloRankResult;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  private async riotMatchIdApi(puuid: string): Promise<any> {
+    const url = `https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/${puuid}/ids?type=ranked&start=0&count=10&api_key=${ConfigService.riotApiKey()}`;
+
+    try {
+      const res = await axios.get(url);
+      const recentRiotMatchIdResult = res.data;
+      return recentRiotMatchIdResult;
     } catch (error) {
       console.error(error);
     }

--- a/libs/common-config/src/job/riot/interface/IRiotApiJobService.ts
+++ b/libs/common-config/src/job/riot/interface/IRiotApiJobService.ts
@@ -2,4 +2,5 @@ import { PushRiotApi } from '../../../../../../apps/push/src/push/dto/PushRiotAp
 
 export interface IRiotApiJobService {
   soloRankResult(summonerId: string);
+  recentMatchIdResult(summonerId: string);
 }

--- a/libs/common-config/src/job/riot/test/stub/RiotApiJobServiceStub.ts
+++ b/libs/common-config/src/job/riot/test/stub/RiotApiJobServiceStub.ts
@@ -2,6 +2,16 @@ import { PushRiotApi } from 'apps/push/src/push/dto/PushRiotApi';
 import { IRiotApiJobService } from '../../interface/IRiotApiJobService';
 
 export class RiotApiJobServiceStub implements IRiotApiJobService {
+  public recentMatchIdResult(summonerId: string) {
+    return [
+      {
+        tier: 'PLATINUM',
+        summonerName: '재카로프',
+        win: 32,
+        lose: 17,
+      },
+    ];
+  }
   public soloRankResult(summonerId: string) {
     return [
       {

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerChangedTierReadSuccess.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerChangedTierReadSuccess.ts
@@ -1,0 +1,70 @@
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { FavoriteSummonerChangedTierRes } from '../../../../../../../apps/api/src/favoriteSummoner/dto/FavoriteSummonerChangedTierRes.dto';
+import { OkSuccess } from '../../common/OkSuccess';
+
+@ApiExtraModels()
+export class FavoriteSummonerChangedTierReadSuccess extends PickType(
+  OkSuccess,
+  ['statusCode'] as const,
+) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '소환사 전적 갱신 조회에 성공했습니다.',
+    description: '소환사 전적 갱신 조회에 성공했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: FavoriteSummonerChangedTierRes,
+    title: '성공 메시지',
+    example: [
+      {
+        summonerId: [
+          {
+            id: '61',
+            match_id: 'KR_5934122430',
+            tier: 'GRANDMASTER',
+            rank: 'I',
+            summoner_id:
+              'GDjFzPPZ3PiiAmPCblXDLv2yRh430fyVjWlpC8zAXaDp9o12bpOZCzfnsw',
+            status: 'tierUp',
+          },
+          {
+            id: '60',
+            match_id: 'KR_5934122430',
+            tier: 'GRANDMASTER',
+            rank: 'I',
+            summoner_id:
+              'GDjFzPPZ3PiiAmPCblXDLv2yRh430fyVjWlpC8zAXaDp9o12bpOZCzfnsw',
+            status: 'tierUp',
+          },
+        ],
+      },
+      {
+        summonerId: [
+          {
+            id: '63',
+            match_id: 'KR_5933496322',
+            tier: 'CHALLENGER',
+            rank: 'I',
+            summoner_id:
+              '8_MjoUjTvMvLLAHQj1PgSCV46Ux1hkGxOy2adI_s2OepAuremBy9ACAmKQ',
+            status: 'tierUp',
+          },
+          {
+            id: '57',
+            match_id: 'KR_5933496322',
+            tier: 'CHALLENGER',
+            rank: 'I',
+            summoner_id:
+              '8_MjoUjTvMvLLAHQj1PgSCV46Ux1hkGxOy2adI_s2OepAuremBy9ACAmKQ',
+            status: 'tierUp',
+          },
+        ],
+      },
+    ],
+    description: '소환사 전적 갱신 조회에 성공했습니다.',
+  })
+  data: FavoriteSummonerChangedTierRes[];
+}

--- a/libs/entity/config/migrateConfig.ts
+++ b/libs/entity/config/migrateConfig.ts
@@ -1,0 +1,6 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ConfigService } from './configService';
+
+const migrateConfig: TypeOrmModuleOptions = ConfigService.ormConfig();
+
+export = migrateConfig;

--- a/libs/entity/migrations/1653285106176-CreateChangedTier.ts
+++ b/libs/entity/migrations/1653285106176-CreateChangedTier.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateChangedTier1653285106176 implements MigrationInterface {
+    name = 'CreateChangedTier1653285106176'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "changed_tier" ("id" BIGSERIAL NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "match_id" character varying NOT NULL, "tier" character varying NOT NULL, "rank" character varying NOT NULL, "summoner_id" character varying, CONSTRAINT "PK_31d97da7f32901d48f4975e7fc5" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "idx_changedTier_1" ON "changed_tier" ("summoner_id") `);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`DROP INDEX "public"."idx_changedTier_1"`);
+        await queryRunner.query(`DROP TABLE "changed_tier"`);
+    }
+
+}

--- a/libs/entity/migrations/1653445543224-CreateChangedTier2.ts
+++ b/libs/entity/migrations/1653445543224-CreateChangedTier2.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateChangedTier21653445543224 implements MigrationInterface {
+    name = 'CreateChangedTier21653445543224'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+}

--- a/libs/entity/migrations/1653446832507-CreateChangedTier3.ts
+++ b/libs/entity/migrations/1653446832507-CreateChangedTier3.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateChangedTier31653446832507 implements MigrationInterface {
+    name = 'CreateChangedTier31653446832507'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE CASCADE`);
+    }
+
+}

--- a/libs/entity/migrations/1653448743659-CreateChangedTier4.ts
+++ b/libs/entity/migrations/1653448743659-CreateChangedTier4.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateChangedTier41653448743659 implements MigrationInterface {
+    name = 'CreateChangedTier41653448743659'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP CONSTRAINT "FK_1c47830b8b74e88b037ab24b177"`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ALTER COLUMN "summoner_id" SET NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" ALTER COLUMN "summoner_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD CONSTRAINT "FK_1c47830b8b74e88b037ab24b177" FOREIGN KEY ("summoner_id") REFERENCES "summoner_record"("summoner_id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/libs/entity/migrations/1653490882415-CreateChangedTier6.ts
+++ b/libs/entity/migrations/1653490882415-CreateChangedTier6.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateChangedTier61653490882415 implements MigrationInterface {
+    name = 'CreateChangedTier61653490882415'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" ADD "status" character varying NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "changed_tier" DROP COLUMN "status"`);
+    }
+
+}

--- a/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
@@ -28,17 +28,25 @@ export class ChangedTier extends BaseTimeEntity {
   })
   summonerId: string;
 
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  status: string;
+
   static async createChangedTier(
     summonerId: string,
     matchId: string,
     tier: string,
     rank: string,
+    status?: string,
   ): Promise<ChangedTier> {
     const changedTier = new ChangedTier();
     changedTier.summonerId = summonerId;
     changedTier.matchId = matchId;
     changedTier.tier = tier;
     changedTier.rank = rank;
+    changedTier.status = status;
     return changedTier;
   }
 }

--- a/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
@@ -1,9 +1,8 @@
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { BaseTimeEntity } from '../BaseTimeEntity';
-import { SummonerRecord } from '../summonerRecord/SummonerRecord.entity';
 
 @Entity()
-@Index('idx_changedTier_1', ['SummonerRecord'])
+@Index('idx_changedTier_1', ['summonerId'])
 export class ChangedTier extends BaseTimeEntity {
   @Column({
     type: 'varchar',
@@ -23,16 +22,11 @@ export class ChangedTier extends BaseTimeEntity {
   })
   rank: string;
 
-  @ManyToOne(
-    () => SummonerRecord,
-    (summonerRecord: SummonerRecord) => summonerRecord.ChangedTier,
-    {
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-    },
-  )
-  @JoinColumn({ name: 'summoner_id', referencedColumnName: 'summonerId' })
-  SummonerRecord: SummonerRecord[] | SummonerRecord | string;
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  summonerId: string;
 
   static async createChangedTier(
     summonerId: string,
@@ -41,7 +35,7 @@ export class ChangedTier extends BaseTimeEntity {
     rank: string,
   ): Promise<ChangedTier> {
     const changedTier = new ChangedTier();
-    changedTier.SummonerRecord = summonerId;
+    changedTier.summonerId = summonerId;
     changedTier.matchId = matchId;
     changedTier.tier = tier;
     changedTier.rank = rank;

--- a/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
@@ -33,4 +33,18 @@ export class ChangedTier extends BaseTimeEntity {
   )
   @JoinColumn({ name: 'summoner_id', referencedColumnName: 'summonerId' })
   SummonerRecord: SummonerRecord[] | SummonerRecord | string;
+
+  static async createChangedTier(
+    summonerId: string,
+    matchId: string,
+    tier: string,
+    rank: string,
+  ): Promise<ChangedTier> {
+    const changedTier = new ChangedTier();
+    changedTier.SummonerRecord = summonerId;
+    changedTier.matchId = matchId;
+    changedTier.tier = tier;
+    changedTier.rank = rank;
+    return changedTier;
+  }
 }

--- a/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
@@ -39,7 +39,7 @@ export class ChangedTier extends BaseTimeEntity {
     matchId: string,
     tier: string,
     rank: string,
-    status?: string,
+    status: string,
   ): Promise<ChangedTier> {
     const changedTier = new ChangedTier();
     changedTier.summonerId = summonerId;

--- a/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTier.entity.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseTimeEntity } from '../BaseTimeEntity';
+import { SummonerRecord } from '../summonerRecord/SummonerRecord.entity';
+
+@Entity()
+@Index('idx_changedTier_1', ['SummonerRecord'])
+export class ChangedTier extends BaseTimeEntity {
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  matchId: string;
+
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  tier: string;
+
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  rank: string;
+
+  @ManyToOne(
+    () => SummonerRecord,
+    (summonerRecord: SummonerRecord) => summonerRecord.ChangedTier,
+    {
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    },
+  )
+  @JoinColumn({ name: 'summoner_id', referencedColumnName: 'summonerId' })
+  SummonerRecord: SummonerRecord[] | SummonerRecord | string;
+}

--- a/libs/entity/src/domain/changedTier/ChangedTierModule.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTierModule.ts
@@ -1,0 +1,11 @@
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { ChangedTier } from './ChangedTier.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChangedTier])],
+  exports: [TypeOrmModule],
+  providers: [],
+  controllers: [],
+})
+export class ChangedTierModule {}

--- a/libs/entity/src/domain/changedTier/ChangedTierPagination.ts
+++ b/libs/entity/src/domain/changedTier/ChangedTierPagination.ts
@@ -1,0 +1,21 @@
+import { Expose } from 'class-transformer';
+
+export class ChangedTierPagination {
+  @Expose({ name: 'id' })
+  id: number;
+
+  @Expose({ name: 'match_id' })
+  matchId: string;
+
+  @Expose({ name: 'tier' })
+  tier: string;
+
+  @Expose({ name: 'rank' })
+  rank: string;
+
+  @Expose({ name: 'summoner_id' })
+  summonerId: string;
+
+  @Expose({ name: 'status' })
+  status: string;
+}

--- a/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, Index, OneToMany } from 'typeorm';
 import { BaseTimeEntity } from '../BaseTimeEntity';
-import { ChangedTier } from '../changedTier/ChangedTier.entity';
 import { FavoriteSummoner } from '../favoriteSummoner/FavoriteSummoner.entity';
 
 @Entity()
@@ -58,12 +57,6 @@ export class SummonerRecord extends BaseTimeEntity {
     (favoriteSummoner: FavoriteSummoner) => favoriteSummoner.SummonerRecord,
   )
   FavoriteSummoner: FavoriteSummoner[];
-
-  @OneToMany(
-    () => ChangedTier,
-    (changedTier: ChangedTier) => changedTier.SummonerRecord,
-  )
-  ChangedTier: ChangedTier[];
 
   static async createSummonerRecord(
     name: string,

--- a/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, Index, OneToMany } from 'typeorm';
 import { BaseTimeEntity } from '../BaseTimeEntity';
+import { ChangedTier } from '../changedTier/ChangedTier.entity';
 import { FavoriteSummoner } from '../favoriteSummoner/FavoriteSummoner.entity';
 
 @Entity()
@@ -57,6 +58,12 @@ export class SummonerRecord extends BaseTimeEntity {
     (favoriteSummoner: FavoriteSummoner) => favoriteSummoner.SummonerRecord,
   )
   FavoriteSummoner: FavoriteSummoner[];
+
+  @OneToMany(
+    () => ChangedTier,
+    (changedTier: ChangedTier) => changedTier.SummonerRecord,
+  )
+  ChangedTier: ChangedTier[];
 
   static async createSummonerRecord(
     name: string,

--- a/libs/entity/src/domain/summonerRecord/SummonerRecordPuuid.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecordPuuid.ts
@@ -1,0 +1,12 @@
+import { Expose } from 'class-transformer';
+
+export class SummonerRecordPuuid {
+  @Expose({ name: 'puuid' })
+  puuid: string;
+
+  static from(puuid: string): SummonerRecordPuuid {
+    const dto = new SummonerRecordPuuid();
+    dto.puuid = puuid;
+    return dto;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "NODE_ENV=development jest --config ./apps/api/test/jest-e2e.json",
-    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --config ./libs/entity/config/ormConfig.ts",
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --config ./libs/entity/config/migrateConfig.ts",
     "typeorm:create": "npm run typeorm migration:create -- -n",
     "typeorm:migrate": "npm run typeorm migration:generate -- -n",
     "typeorm:run": "npm run typeorm migration:run",


### PR DESCRIPTION
## 작업사항
- 소환사 전적 갱신 조회를 위해 API를 도입했음.
- API 도입을 위해 신규 테이블(changed_tier)을 생성
- 테스트 서버에서만 데이터베이스 마이그레이션을 진행했고, 배포 서버에 코드 머지할 때 마이그레이션 진행 예정
- 소환사 전적 갱신 조회를 위해 redis에 rank 값 추가
- 소환사 전적 갱신 푸시 알림에서 rank 값이 변경될 때도 승급했다는 푸시 알림이 가도록 설정

## 관계된 이슈, PR 
#184 